### PR TITLE
use AbstractMessage: super of GeneratedMessage

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -119,7 +119,7 @@ lazy val ratatool = project
   .settings(
     version in ProtobufConfig := protoBufVersion,
     protobufRunProtoc in ProtobufConfig := (args =>
-      com.github.os72.protocjar.Protoc.runProtoc("-v261" +: args.toArray)
+      com.github.os72.protocjar.Protoc.runProtoc("-v330" +: args.toArray)
     )
   )
   .settings(packAutoSettings)

--- a/ratatool/src/main/scala/com/spotify/ratatool/diffy/BigDiffy.scala
+++ b/ratatool/src/main/scala/com/spotify/ratatool/diffy/BigDiffy.scala
@@ -20,7 +20,7 @@ package com.spotify.ratatool.diffy
 import java.net.URI
 
 import com.google.api.services.bigquery.model.{TableFieldSchema, TableRow, TableSchema}
-import com.google.protobuf.GeneratedMessage
+import com.google.protobuf.AbstractMessage
 import com.spotify.ratatool.GcsConfiguration
 import com.spotify.ratatool.samplers.AvroSampler
 import com.spotify.scio._
@@ -233,7 +233,7 @@ object BigDiffy {
     diff(sc.avroFile[T](lhs, schema), sc.avroFile[T](rhs, schema), diffy, keyFn)
 
   /** Diff two ProtoBuf data sets. */
-  def diffProtoBuf[T <: GeneratedMessage : ClassTag](sc: ScioContext,
+  def diffProtoBuf[T <: AbstractMessage : ClassTag](sc: ScioContext,
                                                      lhs: String, rhs: String,
                                                      keyFn: T => String,
                                                      diffy: ProtoBufDiffy[T]): BigDiffy[T] =

--- a/ratatool/src/main/scala/com/spotify/ratatool/diffy/ProtoBufDiffy.scala
+++ b/ratatool/src/main/scala/com/spotify/ratatool/diffy/ProtoBufDiffy.scala
@@ -19,13 +19,13 @@ package com.spotify.ratatool.diffy
 
 import com.google.protobuf.Descriptors.FieldDescriptor.JavaType
 import com.google.protobuf.Descriptors.{Descriptor, FieldDescriptor}
-import com.google.protobuf.GeneratedMessage
+import com.google.protobuf.AbstractMessage
 
 import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
 
 /** Field level diff tool for ProtoBuf records. */
-class ProtoBufDiffy[T <: GeneratedMessage : ClassTag](ignore: Set[String] = Set.empty,
+class ProtoBufDiffy[T <: AbstractMessage : ClassTag](ignore: Set[String] = Set.empty,
                                                       unordered: Set[String] = Set.empty)
   extends Diffy[T](ignore, unordered) {
 
@@ -38,9 +38,9 @@ class ProtoBufDiffy[T <: GeneratedMessage : ClassTag](ignore: Set[String] = Set.
       .invoke(null).asInstanceOf[Descriptor]
 
   // scalastyle:off cyclomatic.complexity
-  private def diff(x: GeneratedMessage, y: GeneratedMessage,
+  private def diff(x: AbstractMessage, y: AbstractMessage,
                    fields: Seq[FieldDescriptor], root: String): Seq[Delta] = {
-    def getField(m: GeneratedMessage, f: FieldDescriptor): AnyRef =
+    def getField(m: AbstractMessage, f: FieldDescriptor): AnyRef =
       if (f.isRepeated) {
         m.getField(f)
       } else {
@@ -57,8 +57,8 @@ class ProtoBufDiffy[T <: GeneratedMessage : ClassTag](ignore: Set[String] = Set.
       } else {
         f.getJavaType match {
           case JavaType.MESSAGE if !f.isRepeated =>
-            val a = getField(x, f).asInstanceOf[GeneratedMessage]
-            val b = getField(y, f).asInstanceOf[GeneratedMessage]
+            val a = getField(x, f).asInstanceOf[AbstractMessage]
+            val b = getField(y, f).asInstanceOf[AbstractMessage]
             if (a == null && b == null) {
               Nil
             } else if (a == null || b == null) {

--- a/ratatool/src/main/scala/com/spotify/ratatool/generators/ProtoBufGenerator.scala
+++ b/ratatool/src/main/scala/com/spotify/ratatool/generators/ProtoBufGenerator.scala
@@ -25,7 +25,7 @@ import com.google.common.cache.{CacheBuilder, CacheLoader, LoadingCache}
 import com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Label
 import com.google.protobuf.Descriptors.Descriptor
 import com.google.protobuf.Descriptors.FieldDescriptor.Type
-import com.google.protobuf.{CodedOutputStream, Descriptors, GeneratedMessage}
+import com.google.protobuf.{CodedOutputStream, Descriptors, AbstractMessage}
 
 import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
@@ -48,7 +48,7 @@ object ProtoBufGenerator {
     })
 
   /** Generate a ProtoBuf record. */
-  def protoBufOf[T <: GeneratedMessage : ClassTag]: T = {
+  def protoBufOf[T <: AbstractMessage : ClassTag]: T = {
     val (desc, parseFn) = cache.get(implicitly[ClassTag[T]].runtimeClass)
     val bytes = generate(desc)
     parseFn.invoke(null, bytes).asInstanceOf[T]

--- a/ratatool/src/main/scala/com/spotify/ratatool/scalacheck/ProtoBufGen.scala
+++ b/ratatool/src/main/scala/com/spotify/ratatool/scalacheck/ProtoBufGen.scala
@@ -17,7 +17,7 @@
 
 package com.spotify.ratatool.scalacheck
 
-import com.google.protobuf.GeneratedMessage
+import com.google.protobuf.AbstractMessage
 import com.spotify.ratatool.generators.ProtoBufGenerator
 import org.scalacheck._
 
@@ -26,7 +26,7 @@ import scala.reflect.ClassTag
 object ProtoBufGen {
 
   /** ScalaCheck generator of ProtoBuf records. */
-  def protoBufOf[T <: GeneratedMessage : ClassTag]: Gen[T] =
+  def protoBufOf[T <: AbstractMessage : ClassTag]: Gen[T] =
     Gen.const(0).map(_ => ProtoBufGenerator.protoBufOf[T])
 
 }


### PR DESCRIPTION
To be compatible with proto 2 and 3 compiled message classes.  Upgrade compiler to v3.3.0

Suggested solution to https://github.com/spotify/ratatool/issues/31.  Maybe it would be better to include implementation for builders and instead change this to `GeneratedMessageV3` for `.asInstanceOf[]` calls?

@idreeskhan 