### PR TITLE
Update GCS connector from 1.6.1 to 1.6.3.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ import Keys._
 
 val algebirdVersion = "0.13.2"
 val avroVersion = "1.8.2"
-val gcsVersion = "1.6.1-hadoop2"
+val gcsVersion = "1.6.3-hadoop2"
 val hadoopVersion = "2.7.3"
 val jodaTimeVersion = "2.9.9"
 val parquetVersion = "1.9.0"


### PR DESCRIPTION
This changes the GCS batch request endpoint to the new per-api endpoint
(https://github.com/GoogleCloudPlatform/bigdata-interop/blob/branch-1.6.x/gcs/CHANGES.txt),
as the old endpoint is being deprecated
(https://developers.googleblog.com/2018/03/discontinuing-support-for-json-rpc-and.html).