### PR TITLE
Change Key Stats to output field level deltas and distances

### DIFF
--- a/ratatool-diffy/diffy.md
+++ b/ratatool-diffy/diffy.md
@@ -10,7 +10,7 @@ BigDiffy will run a [Scio](https://github.com/spotify/scio) pipeline diffing a L
 
  * `global` - Global counts of Diff types (`SAME`, `DIFFERENT`, `MISSING_LHS`, `MISSING_RHS`) seen in the entire dataset (See `GlobalStats`)
  * `fields` - Field level statistics including, but not limited to, the number of records with different values per field, min, max, standard deviation (See `FieldStats` and `DeltaStats`)
- * `keys` - All unique keys found in the two datasets and their Diff types by key in pairs of `<key>\t<diffType>` (See `KeyStats`)
+ * `keys` - All unique keys found in the two datasets and their Diff types by key in pairs of `<key>\t<diffType>` (See `KeyStats`). If fields are different it will output stats for every field which is different, including left and right, as well as distance if the field is `NUMERIC`, `STRING`, or `VECTOR`
 
 For full details on Statistics and output see [BigDiffy.scala](https://github.com/spotify/ratatool/blob/master/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/BigDiffy.scala)
 

--- a/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/Diffy.scala
+++ b/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/Diffy.scala
@@ -42,7 +42,7 @@ case object UnknownDelta extends DeltaValue {
 
 /** Delta value with a known type and computed difference. */
 case class TypedDelta(deltaType: DeltaType.Value, value: Double) extends DeltaValue {
-  override def toString: String = s"$deltaType\t$value}"
+  override def toString: String = s"$deltaType\t$value"
 }
 
 /** Companion objects for `TypedDelta`. */

--- a/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/Diffy.scala
+++ b/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/Diffy.scala
@@ -36,10 +36,14 @@ object DeltaType extends Enumeration {
 sealed trait DeltaValue
 
 /** Delta value of unknown type. */
-case object UnknownDelta extends DeltaValue
+case object UnknownDelta extends DeltaValue {
+  override def toString: String = "UNKNOWN"
+}
 
 /** Delta value with a known type and computed difference. */
-case class TypedDelta(deltaType: DeltaType.Value, value: Double) extends DeltaValue
+case class TypedDelta(deltaType: DeltaType.Value, value: Double) extends DeltaValue {
+  override def toString: String = s"$deltaType\t$value}"
+}
 
 /** Companion objects for `TypedDelta`. */
 object NumericDelta {
@@ -60,7 +64,9 @@ object VectorDelta {
  * @param right right hand side value
  * @param delta delta of numerical values
  */
-case class Delta(field: String, left: Any, right: Any, delta: DeltaValue)
+case class Delta(field: String, left: Any, right: Any, delta: DeltaValue) {
+  override def toString: String = s"$field\t$delta\t$left\t$right"
+}
 
 /**
  * Field level diff tool.


### PR DESCRIPTION
#69 Allows user to consume output data for key-level analysis. Also directly puts differences into the output