### PR TITLE
Rename BigQueryServices to avoid protected error in packed deployment

### DIFF
--- a/ratatool-sampling/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/PatchedBigQueryServices.java
+++ b/ratatool-sampling/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/PatchedBigQueryServices.java
@@ -36,7 +36,7 @@ import javax.annotation.Nullable;
 import org.apache.beam.sdk.values.ValueInSingleWindow;
 
 /** An interface for real, mock, or fake implementations of Cloud BigQuery services. */
-public interface BigQueryServices extends Serializable {
+public interface PatchedBigQueryServices extends Serializable {
 
   /**
    * Returns a real, mock, or fake {@link JobService}.

--- a/ratatool-sampling/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/PatchedBigQueryServicesImpl.java
+++ b/ratatool-sampling/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/PatchedBigQueryServicesImpl.java
@@ -76,12 +76,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * An implementation of {@link BigQueryServices} that actually communicates with the cloud BigQuery
+ * An implementation of {@link PatchedBigQueryServices} that actually communicates with the cloud BigQuery
  * service.
  */
-public class BigQueryServicesImpl implements BigQueryServices {
+public class PatchedBigQueryServicesImpl implements PatchedBigQueryServices {
 
-  private static final Logger LOG = LoggerFactory.getLogger(BigQueryServicesImpl.class);
+  private static final Logger LOG = LoggerFactory.getLogger(PatchedBigQueryServicesImpl.class);
 
   // How frequently to log while polling.
   private static final Duration POLLING_LOG_GAP = Duration.standardMinutes(10);
@@ -124,7 +124,7 @@ public class BigQueryServicesImpl implements BigQueryServices {
   }
 
   @VisibleForTesting
-  static class JobServiceImpl implements BigQueryServices.JobService {
+  static class JobServiceImpl implements PatchedBigQueryServices.JobService {
     private final ApiErrorExtractor errorExtractor;
     private final Bigquery client;
 

--- a/ratatool-sampling/src/main/scala/com/spotify/ratatool/io/BigQueryIO.scala
+++ b/ratatool-sampling/src/main/scala/com/spotify/ratatool/io/BigQueryIO.scala
@@ -24,7 +24,7 @@ import com.google.api.client.googleapis.util.Utils
 import com.google.api.services.bigquery.model.{Table, TableReference, TableRow, TableSchema}
 import com.google.api.services.bigquery.{Bigquery, BigqueryScopes}
 import org.apache.beam.sdk.io.gcp.bigquery.{BigQueryOptions,
-                                            BigQueryServicesImpl,
+                                            PatchedBigQueryServicesImpl,
                                             InsertRetryPolicy,
                                             PatchedBigQueryTableRowIterator}
 import org.apache.beam.sdk.options.PipelineOptionsFactory
@@ -65,7 +65,7 @@ object BigQueryIO {
 
   /** Write records to a BigQuery table. */
   def writeToTable(data: Seq[TableRow], schema: TableSchema, tableRef: TableReference): Unit = {
-    val ds = new BigQueryServicesImpl()
+    val ds = new PatchedBigQueryServicesImpl()
       .getDatasetService(PipelineOptionsFactory.create().as(classOf[BigQueryOptions]))
     val rows = data.map(e =>
       ValueInSingleWindow.of(e, Instant.now(), GlobalWindow.INSTANCE, PaneInfo.NO_FIRING))

--- a/ratatool-sampling/src/main/scala/com/spotify/ratatool/samplers/BigSampler.scala
+++ b/ratatool-sampling/src/main/scala/com/spotify/ratatool/samplers/BigSampler.scala
@@ -36,7 +36,7 @@ import org.apache.avro.Schema.Type
 import org.apache.avro.generic.GenericRecord
 import org.apache.beam.sdk.io.FileSystems
 import org.apache.beam.sdk.io.gcp.bigquery.{BigQueryHelpers, BigQueryIO,
-  BigQueryOptions, BigQueryServicesImpl}
+  BigQueryOptions, PatchedBigQueryServicesImpl}
 import org.apache.beam.sdk.options.PipelineOptions
 import org.slf4j.LoggerFactory
 
@@ -425,7 +425,7 @@ private[samplers] object BigSamplerBigQuery {
     import BigQueryIO.Write.CreateDisposition.CREATE_IF_NEEDED
     import BigQueryIO.Write.WriteDisposition.WRITE_EMPTY
 
-    val patchedBigQueryService = new BigQueryServicesImpl()
+    val patchedBigQueryService = new PatchedBigQueryServicesImpl()
       .getDatasetService(sc.optionsAs[BigQueryOptions])
     if (patchedBigQueryService.getTable(outputTbl) != null) {
       log.info(s"Reuse previous sample at $outputTbl")


### PR DESCRIPTION
This is named the same as `BigQueryServices` which is tries to override. When running packed build the result is that it tries to execute Beams protected class with the same canonical name. This PR avoids that issue.