### PR TITLE
Add amend2 for joinable generators

### DIFF
--- a/ratatool-scalacheck/README.md
+++ b/ratatool-scalacheck/README.md
@@ -1,0 +1,35 @@
+Generators
+=======
+
+Ratatool-Scalacheck contains classes and functions which help with using Scalacheck generators with
+ Avro, Protobuf, and BigQuery.
+
+## Usage
+```scala
+import com.spotify.ratatool.scalacheck._
+import org.scalacheck.Gen
+
+
+val avroGen: Gen[MyRecord] = avroOf[MyRecord]
+val record: MyRecord = avroGen.sample.get
+```
+
+Ratatool also provides `protobufOf[T]` and `tableRowOf(schema)` defined [here](https://github.com/spotify/ratatool/tree/master/ratatool-scalacheck/src/main/scala/com/spotify/ratatool/scalacheck).
+
+It also enables modifying specific fields using `.amend()`. For Protobuf, the record has to be
+ converted to a Builder first.
+
+```scala
+val intGen = Gen.choose(0, 10)
+avroGen.amend(intGen)(_.setMyIntField)
+```
+
+To use the same value in two records, use `amend2()` after converting `(Gen[A], Gen[B])` to
+ `Gen[(A, B)]` with `tupled()`.
+ 
+ ```scala
+val otherGen: Gen[OtherRecord] = avroOf[OtherRecord]
+val keyGen = Arbitrary.arbString.arbitrary
+
+(avroGen, otherGen).tupled.amend2(keyGen)(_.setMyIntField, _.setOtherIntField)
+```

--- a/ratatool-scalacheck/README.md
+++ b/ratatool-scalacheck/README.md
@@ -2,7 +2,7 @@ Generators
 =======
 
 Ratatool-Scalacheck contains classes and functions which help with using Scalacheck generators with
- Avro, Protobuf, and BigQuery.
+ Avro, Protobuf, and BigQuery. For examples of using Generators see [ratatool-examples](https://github.com/spotify/ratatool/tree/master/ratatool-examples).
 
 ## Usage
 ```scala


### PR DESCRIPTION
Possibly simplifies #81 
This is likely more specifically for joinable data but could theoretically expand API up to Tuple22 if needed. Premise is that for building joinable dataset you build a Gen of tuple and then amend2 over that tuple. This is what I have been doing on my own already and this trims down the necessary work by a bit. Still not ideal but a slight improvement.