### PR TITLE
Make CaseClassDiffy's MapEncoder trait serializable

### DIFF
--- a/ratatool-shapeless/src/main/scala/com/spotify/ratatool/shapeless/CaseClassDiffy.scala
+++ b/ratatool-shapeless/src/main/scala/com/spotify/ratatool/shapeless/CaseClassDiffy.scala
@@ -26,7 +26,8 @@ import shapeless.labelled.FieldType
 
 import scala.reflect.ClassTag
 
-sealed trait MapEncoder[A] {
+@SerialVersionUID(42L)
+sealed trait MapEncoder[A] extends Serializable {
   def toMap(in: A): Map[String, Any]
 }
 


### PR DESCRIPTION
A patch for #105 (issue #122). The trait has to be serialisable to be sent over the network. 