### PR TITLE
Refactors of BigSamplerAvro and adds ability to control hashing of byte  sequences.

### DIFF
--- a/ratatool-sampling/src/main/scala/com/spotify/ratatool/samplers/BigSamplerAvro.scala
+++ b/ratatool-sampling/src/main/scala/com/spotify/ratatool/samplers/BigSamplerAvro.scala
@@ -17,205 +17,175 @@
 
 package com.spotify.ratatool.samplers
 
-import java.io.IOException
 import java.nio.ByteBuffer
 import java.util.{List => JList}
 
 import com.google.common.hash.Hasher
 import com.spotify.ratatool.io.{AvroIO, FileStorage}
-import com.spotify.ratatool.samplers.util.{Precision, SampleDistribution}
+import com.spotify.ratatool.samplers.util.{ByteEncoding, Precision, RawEncoding, SampleDistribution}
 import com.spotify.scio.ScioContext
 import com.spotify.scio.io.{Tap, Taps}
 import org.apache.avro.Schema
 import org.apache.avro.Schema.Type
-import org.apache.avro.generic.{GenericData, GenericFixed, GenericRecord}
-import org.apache.commons.codec.binary.Hex
+import org.apache.avro.generic._
+import org.apache.avro.specific.SpecificData
 import org.slf4j.LoggerFactory
 
-import scala.collection.JavaConverters._
 import scala.annotation.tailrec
+import scala.collection.JavaConverters._
 import scala.concurrent.Future
 
 private[samplers] object BigSamplerAvro {
   private val log = LoggerFactory.getLogger(BigSamplerAvro.getClass)
 
-  // scalastyle:off cyclomatic.complexity
-  @tailrec
-  private[samplers] def hashAvroField(schema: Schema)(r: GenericRecord,
-                                                      fieldStr: String,
-                                                      hasher: Hasher): Hasher = {
-    val recordSchema = getRecordSchema(schema)
-    val subfields = fieldStr.split(BigSampler.fieldSep)
-    val field = recordSchema.getFields.asScala.find(_.name == subfields.head).getOrElse {
-      throw new NoSuchElementException(s"Can't find field $fieldStr in avro schema $schema")
-    }
-    val v = r.get(subfields.head)
-    if (v == null) {
-      log.debug(s"Field `${field.name}` of type ${field.schema.getType} is null - won't account" +
-        s" for hash")
-      hasher
+  private def resolveUnion(schema: Schema, value: Object): Schema = {
+    if(schema.getType == Type.UNION) {
+      schema.getTypes.get(SpecificData.get().resolveUnion(schema, value))
     } else {
-      field.schema.getType match {
-        case Type.RECORD =>
-          hashAvroField(field.schema)(
-            v.asInstanceOf[GenericRecord],
-            subfields.tail.mkString(BigSampler.fieldSep.toString),
-            hasher)
-        case Type.UNION => hashAvroUnionField(field, v, hasher)
-        case Type.ARRAY => hashAvroArrayField(field, v, hasher)
-        //  Type.MAP =>
-        case t => hashPrimitive(field, t, v, hasher)
-      }
-    }
-  }
-  // scalastyle:on cyclomatic.complexity
-  private def hashBytes(bytes: Array[Byte], hasher: Hasher): Hasher = {
-    // Convert to string to have hex representations of bytes and raw bytes consistent
-    hasher.putString(Hex.encodeHexString(bytes), BigSampler.utf8Charset)
-  }
-
-  // scalastyle:off cyclomatic.complexity
-  private def hashAvroArrayField(field: Schema.Field, v: AnyRef, hasher: Hasher): Hasher = {
-    field.schema.getElementType.getType match {
-      case Type.NULL =>
-        // ignore nulls
-        hasher
-      case t => v.asInstanceOf[JList[AnyRef]].asScala.foldLeft(hasher)((hasher, e) =>
-        hashPrimitive(field, t, e, hasher))
+      schema
     }
   }
 
-  // scalastyle:off cyclomatic.complexity
-  private def hashAvroUnionField(field: Schema.Field, v: AnyRef, hasher: Hasher): Hasher = {
-    val types = field.schema.getTypes.asScala
+  private[samplers] def getField(r: GenericRecord, fieldPath: List[String], schema: Schema)
+  : (String, Schema, AnyRef) = {
+    // Resolve the record in case it is a union
+    val recordSchema = resolveUnion(schema, r)
 
-    types.foldLeft(hasher)( (hasher, p) =>
-      p.getType match {
-        case Type.NULL =>
-          // ignore nulls
-          hasher
-        case t => hashPrimitive(field, t, v, hasher)
-      }
-    )
-  }
-  // scalastyle:on cyclomatic.complexity
+    // Get the field using the resolved schema
+    val field = Some(recordSchema.getField(fieldPath.head)).getOrElse {
+      throw new NoSuchElementException(s"Can't find field ${fieldPath.head} in avro schema $schema")
+    }
 
-  // scalastyle:off cyclomatic.complexity
-  private def hashPrimitive(field: Schema.Field, fieldType: Schema.Type, v: AnyRef, hasher: Hasher)
-  : Hasher = {
-    fieldType match {
-      case Type.ENUM => hashEnum(field, v, hasher)
-      case Type.STRING => hasher.putString(v.asInstanceOf[CharSequence], BigSampler.utf8Charset)
-      case Type.BYTES => hashBytes(field, v, hasher)
-      // to keep it consistent with BigQuery INT - convert int to long
-      case Type.INT => hasher.putLong(v.asInstanceOf[Int].toLong)
-      case Type.LONG => hasher.putLong(v.asInstanceOf[Long])
-      case Type.FLOAT => hasher.putFloat(v.asInstanceOf[Float])
-      case Type.DOUBLE => hasher.putDouble(v.asInstanceOf[Double])
-      case Type.BOOLEAN => hasher.putBoolean(v.asInstanceOf[Boolean])
-      case Type.FIXED => hashBytes(field, v, hasher)
-      //  Type.MAP =>
-      case t => throw new UnsupportedOperationException(
-        s"Type `${field.schema.getType}` of `${field.name}` is not supported as sampling key!")
-    }
-  }
-  // scalastyle:on cyclomatic.complexity
+    // Get the value of the field
+    val fieldValue = r.get(fieldPath.head)
 
-  private def hashEnum(field: Schema.Field, v: AnyRef, hasher: Hasher): Hasher = {
-    // Enum has two possible types depending on if v came from a specific or generic record
-    v match {
-      case sv: Enum[_] => hasher.putString(sv.name, BigSampler.utf8Charset)
-      case gv: GenericData.EnumSymbol => hasher.putString(gv.toString, BigSampler.utf8Charset)
-      case _ => throw new UnsupportedOperationException(
-        s"Internal type of `${field.name}` not consistent with `${field.schema.getType}`!")
-    }
-  }
+    // Get the resolved field schema for unions
+    val fieldSchema = resolveUnion(field.schema, fieldValue)
 
-  private def hashBytes(field: Schema.Field, v: AnyRef, hasher: Hasher): Hasher = {
-    // Convert to string to have hex representations of bytes and raw bytes consistent
-    v match {
-      case sv: Array[Byte] =>
-        hasher.putString(Hex.encodeHexString(sv), BigSampler.utf8Charset)
-      case gv: ByteBuffer =>
-        hasher.putString(Hex.encodeHexString(gv.array()), BigSampler.utf8Charset)
-      case fv: GenericFixed =>
-        hasher.putString(Hex.encodeHexString(fv.bytes()), BigSampler.utf8Charset)
-      case _ => throw new UnsupportedOperationException(
-        s"Internal type of `${field.name}` not consistent with `${field.schema.getType}`!")
-    }
+    (field.name, fieldSchema, fieldValue)
   }
-
-  private def getRecordSchema(schema: Schema): Schema = {
-    schema.getType match {
-      case Type.UNION => schema.getTypes.asScala.head
-      case Type.RECORD => schema
-      case _ => throw new IOException(s"Can't recognise schema `$schema` as record")
-    }
-  }
-
-  @tailrec
-  private def fieldInAvroSchema(schema: Schema, fieldStr: String): Boolean = {
-    val recordSchema = getRecordSchema(schema)
-    val subfields = fieldStr.split(BigSampler.fieldSep)
-    val fieldOpt = recordSchema.getFields.asScala.find(_.name == subfields.head)
-    if (fieldOpt.isEmpty) {
-      false
-    } else {
-      val field = fieldOpt.get
-      field.schema.getType match {
-        case Type.RECORD =>
-          fieldInAvroSchema(field.schema, subfields.tail.mkString(BigSampler.fieldSep.toString))
-        case Type.ENUM | Type.STRING | Type.BYTES | Type.INT | Type.LONG| Type.FLOAT | Type.DOUBLE
-             | Type.BOOLEAN => true
-        case  t => throw new UnsupportedOperationException(
-          s"Type `${field.schema.getType}` of `${field.name}` is not supported as sampling key!")
-      }
-    }
-  }
-
-  // scalastyle:off cyclomatic.complexity
-  // TODO: Potentially reduce this and hashAvroField to a single function
-  @tailrec
-  private[samplers] def getAvroField(r: GenericRecord,
-                                     fieldStr: String,
-                                     schema: Schema): Any = {
-    val recordSchema = getRecordSchema(schema)
-    val subfields = fieldStr.split(BigSampler.fieldSep)
-    val field = recordSchema.getFields.asScala.find(_.name == subfields.head).getOrElse {
-      throw new NoSuchElementException(s"Can't find field $fieldStr in avro schema $schema")
-    }
-    val v = r.get(subfields.head)
-    if (v == null) {
-      log.debug(s"Field `${field.name}` of type ${field.schema.getType} is null, will not look" +
-        " for nested values")
-      null
-    } else {
-      field.schema.getType match {
-        case Type.RECORD if fieldStr.nonEmpty =>
-          getAvroField(
-            v.asInstanceOf[GenericRecord],
-            subfields.tail.mkString(BigSampler.fieldSep.toString),
-            field.schema)
-        case Type.ENUM => v.asInstanceOf[Enum[_]]
-        case Type.STRING => v.asInstanceOf[CharSequence]
-        case Type.BYTES => v.asInstanceOf[Array[Byte]]
-        case Type.INT => v.asInstanceOf[Int].toLong
-        case Type.LONG => v.asInstanceOf[Long]
-        case Type.FLOAT => v.asInstanceOf[Float]
-        case Type.DOUBLE => v.asInstanceOf[Double]
-        case Type.BOOLEAN => v.asInstanceOf[Boolean]
-        //TODO: Support Union type
-        case _ => throw new Exception(s"Current type ${field.schema.getType} is unsupported " +
-          s"or field $fieldStr does not refer to a single field.")
-      }
-    }
-  }
-  // scalastyle:on cyclomatic.complexity
 
   private[samplers] def buildKey(schema: => Schema,
                                  distributionFields: Seq[String])(gr: GenericRecord)
-  : Set[String] = {
-    distributionFields.map(f => getAvroField(gr, f, schema).toString).toSet
+  : Set[Any] = {
+    distributionFields.map{f =>
+      val field = getAvroField(gr, f.split(BigSampler.fieldSep).toList, schema)
+      // Avro caches toString in the Utf8 class which results in an IllegalMutationException
+      // later on if we don't materialize the string once before. Ignoring this prevents us
+      // from printing the key in e.g. SamplerSCollectionFunctions.logDistributionDiffs.
+      field.toString
+      field
+    }.toSet
+  }
+
+  @tailrec
+  private[samplers] def getAvroField(r: GenericRecord,
+                                     fieldPath: List[String],
+                                     schema: Schema): Any = {
+
+    val (fieldName, fieldSchema, fieldValue) = getField(r, fieldPath, schema)
+
+    if (fieldValue == null) {
+      log.debug(s"Field `${fieldName}` of type ${fieldSchema.getType} is null, will not look" +
+      " for nested values")
+      null
+    } else {
+      fieldSchema.getType match {
+        case Type.RECORD if fieldPath.tail.nonEmpty =>
+          getAvroField(
+            fieldValue.asInstanceOf[GenericRecord],
+            fieldPath.tail,
+            fieldSchema)
+        case Type.ARRAY | Type.MAP => throw new UnsupportedOperationException(
+          s"Type `${fieldSchema.getType}` of `${fieldName}` is not supported as stratification " +
+            s"key!")
+        case _ => fieldValue
+      }
+    }
+  }
+
+  private[samplers] def hashAvroField(schema: Schema)
+                                     (r: GenericRecord, fieldStr: String, hasher: Hasher)
+  : Hasher = {
+    hashAvroField(schema, r, fieldStr.split(BigSampler.fieldSep).toList, hasher)
+  }
+
+  private[samplers] def hashAvroField(schema: Schema, r: GenericRecord,
+                                                      fieldPath: List[String],
+                                                      hasher: Hasher)
+  : Hasher = {
+    val (fieldName, fieldSchema, fieldValue) = getField(r, fieldPath, schema)
+    if (fieldValue == null) {
+      log.debug(
+        s"Field `${fieldName}` of type ${fieldSchema.getType} is null - won't account for hash")
+      hasher
+    } else {
+      val vs = if(fieldSchema.getType == Type.ARRAY) {
+        val elementType = fieldSchema.getElementType
+        fieldValue.asInstanceOf[JList[AnyRef]].asScala.map(v =>  (v, resolveUnion(elementType, v)))
+      } else {
+        Seq((fieldValue, fieldSchema))
+      }
+
+      vs.foldLeft(hasher){ case (h, (v, s)) =>
+        s.getType match {
+          case Type.RECORD =>
+            hashAvroField(s,
+              v.asInstanceOf[GenericRecord],
+              fieldPath.tail,
+              hasher)
+          case _ => hashPrimitive(fieldName, s, v, h)
+        }
+      }
+    }
+  }
+
+  // scalastyle:off cyclomatic.complexity
+  private def hashPrimitive(fieldName: String, fieldSchema: Schema, fieldValue: AnyRef,
+                            hasher: Hasher)
+  : Hasher = {
+    fieldSchema.getType match {
+      case Type.ENUM => hashEnum(fieldName, fieldSchema, fieldValue, hasher)
+      case Type.STRING =>
+        hasher.putString(fieldValue.asInstanceOf[CharSequence], BigSampler.utf8Charset)
+      case Type.BYTES => hashBytes(fieldName, fieldSchema, fieldValue, hasher)
+      // to keep it consistent with BigQuery INT - convert int to long
+      case Type.INT => hasher.putLong(fieldValue.asInstanceOf[Int].toLong)
+      case Type.LONG => hasher.putLong(fieldValue.asInstanceOf[Long])
+      case Type.FLOAT => hasher.putFloat(fieldValue.asInstanceOf[Float])
+      case Type.DOUBLE => hasher.putDouble(fieldValue.asInstanceOf[Double])
+      case Type.BOOLEAN => hasher.putBoolean(fieldValue.asInstanceOf[Boolean])
+      case Type.FIXED => hashBytes(fieldName, fieldSchema, fieldValue, hasher)
+      case Type.NULL => hasher // Ignore nulls
+      case t => throw new UnsupportedOperationException(
+        s"Type `${fieldSchema.getType}` of `${fieldName}` is not supported as sampling key!")
+    }
+  }
+
+  // scalastyle:on cyclomatic.complexity
+
+  private def hashEnum(fieldName: String, fieldSchema: Schema, fieldValue: AnyRef, hasher: Hasher)
+  : Hasher = {
+    // Enum has two possible types depending on if v came from a specific or generic record
+    fieldValue match {
+      case sv: Enum[_] => hasher.putString(sv.name, BigSampler.utf8Charset)
+      case gv: GenericData.EnumSymbol => hasher.putString(gv.toString, BigSampler.utf8Charset)
+      case _ => throw new UnsupportedOperationException(
+        s"Internal type of `${fieldName}` not consistent with `${fieldSchema.getType}`!")
+    }
+  }
+
+  private def hashBytes(fieldName: String, fieldSchema: Schema, fieldValue: AnyRef,
+                        hasher: Hasher)
+  : Hasher = {
+    // Types depend on whether v came from a specific or generic record
+    fieldValue match {
+      case sv: Array[Byte] => hasher.putBytes(sv)
+      case gv: ByteBuffer => hasher.putBytes(gv.array())
+      case fv: GenericFixed => hasher.putBytes(fv.bytes())
+      case _ => throw new UnsupportedOperationException(
+        s"Internal type of `${fieldName}` not consistent with `${fieldSchema.getType}`!")
+    }
   }
 
   //scalastyle:off method.length cyclomatic.complexity parameter.number
@@ -228,7 +198,8 @@ private[samplers] object BigSamplerAvro {
                                distribution: Option[SampleDistribution],
                                distributionFields: Seq[String],
                                precision: Precision,
-                               maxKeySize: Int)
+                               maxKeySize: Int,
+                               byteEncoding: ByteEncoding = RawEncoding)
   : Future[Tap[GenericRecord]] = {
     val schema = AvroIO.getAvroSchemaFromFile(input)
     val outputParts = if (output.endsWith("/")) output + "part*" else output + "/part*"
@@ -238,12 +209,11 @@ private[samplers] object BigSamplerAvro {
     } else {
       log.info(s"Will sample from: $input, output will be $output")
       val schemaSer = schema.toString(false)
-      @transient lazy val schemaSerDe = new Schema.Parser().parse(schemaSer)
 
       val coll = sc.avroFile[GenericRecord](input, schema)
 
       val sampledCollection = sampleAvro(coll, fraction, schema, fields, seed, distribution,
-        distributionFields, precision, maxKeySize)
+        distributionFields, precision, maxKeySize, byteEncoding)
 
 
       val r = sampledCollection.saveAsAvroFile(output, schema = schema)

--- a/ratatool-sampling/src/main/scala/com/spotify/ratatool/samplers/BigSamplerProto.scala
+++ b/ratatool-sampling/src/main/scala/com/spotify/ratatool/samplers/BigSamplerProto.scala
@@ -28,8 +28,8 @@ private[samplers] object BigSamplerProto {
   private val log = LoggerFactory.getLogger(BigSamplerProto.getClass)
 
   private[samplers] def buildKey(distributionFields: Seq[String])(m: AbstractMessage)
-  : Set[String] = {
-    distributionFields.map(f => getProtobufField(m, f).toString).toSet
+  : Set[Any] = {
+    distributionFields.map(f => getProtobufField(m, f)).toSet
   }
 
   // scalastyle:off cyclomatic.complexity
@@ -80,15 +80,7 @@ private[samplers] object BigSamplerProto {
       field.getJavaType match {
         case JavaType.MESSAGE => getProtobufField(
           v.asInstanceOf[AbstractMessage], subfields.tail.mkString("."))
-        case JavaType.INT => v.asInstanceOf[Int]
-        case JavaType.LONG => v.asInstanceOf[Long]
-        case JavaType.FLOAT => v.asInstanceOf[Float]
-        case JavaType.DOUBLE => v.asInstanceOf[Double]
-        case JavaType.BOOLEAN => v.asInstanceOf[Boolean]
-        case JavaType.STRING => v.asInstanceOf[CharSequence]
-        case JavaType.BYTE_STRING => v.asInstanceOf[ByteString].toByteArray
-        case JavaType.ENUM => v.asInstanceOf[Enum[_]].name
-        // Array, Union
+        case _ => v
       }
     }
   }

--- a/ratatool-sampling/src/main/scala/com/spotify/ratatool/samplers/util/ByteHasher.scala
+++ b/ratatool-sampling/src/main/scala/com/spotify/ratatool/samplers/util/ByteHasher.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.ratatool.samplers.util
+
+import java.nio.charset.Charset
+
+import com.google.common.hash.{Funnel, HashCode, Hasher}
+import com.google.common.io.BaseEncoding
+
+object ByteHasher {
+  def wrap(hasher: Hasher, be: ByteEncoding, charset: Charset): Hasher = {
+    be match {
+      case RawEncoding => hasher
+      case HexEncoding =>
+        new ByteHasher(hasher, BaseEncoding.base16.lowerCase, charset)
+      case Base64Encoding =>
+        new ByteHasher(hasher, BaseEncoding.base64, charset)
+    }
+  }
+}
+
+class ByteHasher(hasher: Hasher, encoding: BaseEncoding, charset: Charset) extends Hasher {
+  override def putByte(b: Byte): Hasher = {
+    hasher.putString(encoding.encode(Array(b)), charset)
+  }
+
+  override def putBytes(bytes: Array[Byte]): Hasher = {
+    hasher.putString(encoding.encode(bytes), charset)
+  }
+
+  override def putBytes(bytes: Array[Byte], off: Int, len: Int): Hasher = {
+    hasher.putString(encoding.encode(bytes, off, len), charset)
+  }
+
+  override def putShort(s: Short): Hasher = hasher.putShort(s)
+
+  override def putInt(i: Int): Hasher = hasher.putInt(i)
+
+  override def putLong(l: Long): Hasher = hasher.putLong(l)
+
+  override def putFloat(f: Float): Hasher = hasher.putFloat(f)
+
+  override def putDouble(d: Double): Hasher = hasher.putDouble(d)
+
+  override def putBoolean(b: Boolean): Hasher = hasher.putBoolean(b)
+
+  override def putChar(c: Char): Hasher = hasher.putChar(c)
+
+  override def putUnencodedChars(cs: CharSequence): Hasher = hasher.putUnencodedChars(cs)
+
+  override def putString(cs: CharSequence, charset: Charset): Hasher = hasher.putString(cs, charset)
+
+  override def putObject[T](instance: T, funnel: Funnel[_ >: T]): Hasher =
+    hasher.putObject(instance, funnel)
+
+  override def hash(): HashCode = hasher.hash()
+}

--- a/ratatool-sampling/src/main/scala/com/spotify/ratatool/samplers/util/Util.scala
+++ b/ratatool-sampling/src/main/scala/com/spotify/ratatool/samplers/util/Util.scala
@@ -17,6 +17,11 @@
 
 package com.spotify.ratatool.samplers.util
 
+import java.nio.charset.Charset
+
+import com.google.common.hash.{Funnel, HashCode, Hasher}
+import com.google.common.io.BaseEncoding
+
 trait SampleDistribution
 case object StratifiedDistribution extends SampleDistribution
 case object UniformDistribution extends SampleDistribution
@@ -59,6 +64,28 @@ object Precision {
       Exact
     } else {
       Approximate
+    }
+  }
+}
+
+trait ByteEncoding
+case object RawEncoding extends ByteEncoding
+case object HexEncoding extends ByteEncoding
+case object Base64Encoding extends ByteEncoding
+
+object ByteEncoding {
+  def fromString(s: String): ByteEncoding = {
+    if(s == "raw") {
+      RawEncoding
+    }
+    else if(s == "hex") {
+      HexEncoding
+    }
+    else if(s == "base64") {
+      Base64Encoding
+    }
+    else {
+      throw new IllegalArgumentException(s"Invalid byte encoding $s")
     }
   }
 }

--- a/ratatool-sampling/src/test/scala/com/spotify/ratatool/samplers/util/ByteWrappedHasherTest.scala
+++ b/ratatool-sampling/src/test/scala/com/spotify/ratatool/samplers/util/ByteWrappedHasherTest.scala
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2018 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.ratatool.samplers.util
+
+import com.google.common.hash.{Funnel, PrimitiveSink}
+import com.google.common.io.BaseEncoding
+import com.spotify.ratatool.samplers.BigSampler
+import org.scalacheck.Prop.forAll
+import org.scalacheck.Properties
+import org.scalatest.{FlatSpec, Matchers}
+
+object ByteWrappedHasherTest extends Properties("ByteWrappedHasher") {
+  private val testSeed = Some(42)
+  private def newHasher() = BigSampler.hashFun(seed = testSeed)
+
+  property("wrapped hasher produces the same hash as original hasher for ints") = forAll {
+    i: Int =>
+    val hasher = newHasher
+    val wrappedHasher =
+      ByteHasher.wrap(newHasher, RawEncoding, BigSampler.utf8Charset)
+
+    hasher.putInt(i)
+    wrappedHasher.putInt(i)
+
+    hasher.hash == wrappedHasher.hash
+  }
+
+  property("wrapped hasher produces the same hash as original hasher for shorts") = forAll {
+    s: Short =>
+    val hasher = newHasher
+    val wrappedHasher =
+      ByteHasher.wrap(newHasher, HexEncoding, BigSampler.utf8Charset)
+
+    hasher.putShort(s)
+    wrappedHasher.putShort(s)
+
+    hasher.hash == wrappedHasher.hash
+  }
+
+  property("wrapped hasher produces the same hash as original hasher for longs") = forAll {
+    l: Long =>
+      val hasher = newHasher
+      val wrappedHasher =
+        ByteHasher.wrap(newHasher, HexEncoding, BigSampler.utf8Charset)
+
+      hasher.putLong(l)
+      wrappedHasher.putLong(l)
+
+      hasher.hash == wrappedHasher.hash
+  }
+
+  property("wrapped hasher produces the same hash as original hasher for floats") = forAll {
+    f: Float =>
+      val hasher = newHasher
+      val wrappedHasher =
+        ByteHasher.wrap(newHasher, HexEncoding, BigSampler.utf8Charset)
+
+      hasher.putFloat(f)
+      wrappedHasher.putFloat(f)
+
+      hasher.hash == wrappedHasher.hash
+  }
+
+  property("wrapped hasher produces the same hash as original hasher for doubles") = forAll {
+    d: Float =>
+      val hasher = newHasher
+      val wrappedHasher =
+        ByteHasher.wrap(newHasher, HexEncoding, BigSampler.utf8Charset)
+
+      hasher.putDouble(d)
+      wrappedHasher.putDouble(d)
+
+      hasher.hash == wrappedHasher.hash
+  }
+
+  property("wrapped hasher produces the same hash as original hasher for booleans") = forAll {
+    b: Boolean =>
+      val hasher = newHasher
+      val wrappedHasher =
+        ByteHasher.wrap(newHasher, HexEncoding, BigSampler.utf8Charset)
+
+      hasher.putBoolean(b)
+      wrappedHasher.putBoolean(b)
+
+      hasher.hash == wrappedHasher.hash
+  }
+
+  property("wrapped hasher produces the same hash as original hasher for chars") = forAll {
+    c: Char =>
+      val hasher = newHasher
+      val wrappedHasher =
+        ByteHasher.wrap(newHasher, HexEncoding, BigSampler.utf8Charset)
+
+      hasher.putChar(c)
+      wrappedHasher.putChar(c)
+
+      hasher.hash == wrappedHasher.hash
+  }
+
+  property("wrapped hasher produces the same hash as original hasher for char sequences") = forAll {
+    s: String =>
+      val hasher = newHasher
+      val wrappedHasher =
+        ByteHasher.wrap(newHasher, HexEncoding, BigSampler.utf8Charset)
+
+      hasher.putUnencodedChars(s)
+      wrappedHasher.putUnencodedChars(s)
+
+      hasher.hash == wrappedHasher.hash
+  }
+
+  property("wrapped hasher produces the same hash as original hasher for strings") = forAll {
+    s: String =>
+      val hasher = newHasher
+      val wrappedHasher =
+        ByteHasher.wrap(newHasher, HexEncoding, BigSampler.utf8Charset)
+
+      hasher.putString(s, BigSampler.utf8Charset)
+      wrappedHasher.putString(s, BigSampler.utf8Charset)
+
+      hasher.hash == wrappedHasher.hash
+  }
+
+  object StringFunnel extends Funnel[String] {
+    override def funnel(from: String, into: PrimitiveSink): Unit = {
+      into.putString(from, BigSampler.utf8Charset)
+    }
+  }
+
+  property("wrapped hasher produces the same hash as original hasher for objects") = forAll {
+    s: String =>
+      val hasher = newHasher
+      val wrappedHasher =
+        ByteHasher.wrap(newHasher, HexEncoding, BigSampler.utf8Charset)
+
+      hasher.putObject(s, StringFunnel)
+      wrappedHasher.putObject(s, StringFunnel)
+
+      hasher.hash == wrappedHasher.hash
+  }
+
+  property("wrapped hex hasher correctly encodes bytes as hex") = forAll {
+    ba: Array[Byte] =>
+      val hasher1 =
+        ByteHasher.wrap(newHasher, HexEncoding, BigSampler.utf8Charset)
+      val hasher2 =
+        ByteHasher.wrap(newHasher, HexEncoding, BigSampler.utf8Charset)
+
+      val s = BaseEncoding.base16().lowerCase.encode(ba)
+
+      hasher1.putBytes(ba)
+      hasher2.putString(s, BigSampler.utf8Charset)
+      assert(hasher1.hash == hasher2.hash)
+
+      if(ba.length >= 1) {
+        hasher1.putBytes(ba, 0, 1)
+        hasher2.putString(s.slice(0, 2), BigSampler.utf8Charset)
+        assert(hasher1.hash == hasher2.hash)
+
+        hasher1.putByte(ba(0))
+        hasher2.putString(s.slice(0, 2), BigSampler.utf8Charset)
+      }
+
+      hasher1.hash == hasher2.hash
+  }
+}
+
+class ByteHasherEqualsTest extends FlatSpec with Matchers {
+  private val testSeed = Some(42)
+  private def newHasher() = BigSampler.hashFun(seed = testSeed)
+
+  "WrappedByteHasher" should "not alter the hasher using the raw encoding" in {
+    val hasher = newHasher
+    val wrappedHasher = ByteHasher.wrap(hasher, RawEncoding, BigSampler.utf8Charset)
+    assert(hasher.equals(wrappedHasher))
+  }
+}


### PR DESCRIPTION
* Refactors BigSamplerAvro to only perform the type checking in one
place.
* Avoids string serialization in buildKey.
* Makes BigSamplerAvro and BigSamplerBigQuery consistent in how they
handle repeated fields.
* Adds ability to control how Bytes fields are hashed, this is to allow
users to hash strings and byte sequences consistently when the strings
are string encoded byte sequences.
* Handles Avro unions properly.