### PR TITLE
Support multiple keys in bigdiffy

### DIFF
--- a/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/BigDiffy.scala
+++ b/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/BigDiffy.scala
@@ -419,7 +419,9 @@ object BigDiffy extends Command {
       } else {
         get(xs, i + 1, r.get(xs(i)).asInstanceOf[GenericRecord])
       }
-    (r: GenericRecord) =>  keys.map { k => get(k.split('.'), 0, r) }.mkString("_")
+
+    val xs = keys.map(_.split('.'))
+    (r: GenericRecord) =>  xs.map { x => get(x, 0, r) }.mkString("_")
   }
 
   private def tableRowKeyFn(keys: Seq[String]): TableRow => String = {
@@ -431,7 +433,8 @@ object BigDiffy extends Command {
         get(xs, i + 1, r.get(xs(i)).asInstanceOf[java.util.Map[String, AnyRef]])
       }
 
-    (r: TableRow) =>  keys.map { k => get(k.split('.'), 0, r) }.mkString("_")
+    val xs = keys.map(_.split('.'))
+    (r: TableRow) =>  xs.map { x => get(x, 0, r) }.mkString("_")
   }
 
   def pathWithShards(path: String): String = path.replaceAll("\\/+$", "") + "/part"

--- a/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/BigDiffy.scala
+++ b/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/BigDiffy.scala
@@ -29,7 +29,7 @@ import com.spotify.scio.values.SCollection
 import com.twitter.algebird._
 import org.apache.avro.Schema
 import org.apache.avro.generic.GenericRecord
-import org.apache.beam.sdk.io.{FileSystems, TextIO}
+import org.apache.beam.sdk.io.TextIO
 
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
@@ -383,7 +383,7 @@ object BigDiffy extends Command {
         |
         |  --input-mode=(avro|bigquery)     Diff-ing Avro or BQ records
         |  [--output-mode=(gcs|bigquery)]   Saves to a text file in GCS or a BigQuery dataset. Defaults to GCS
-        |  --key=<key>                      '.' separated key field
+        |  --key=<key>                      '.' separated key field. Specify multiple --key params for multi key usage.
         |  --lhs=<path>                     LHS File path or BigQuery table
         |  --rhs=<path>                     RHS File path or BigQuery table
         |  --output=<output>                File path prefix for output
@@ -411,7 +411,7 @@ object BigDiffy extends Command {
     sys.exit(1)
   }
 
-  private def avroKeyFn(keys: Seq[String]): GenericRecord => String = {
+  private[diffy] def avroKeyFn(keys: Seq[String]): GenericRecord => String = {
     @tailrec
     def get(xs: Array[String], i: Int, r: GenericRecord): String =
       if (i == xs.length - 1) {
@@ -424,7 +424,7 @@ object BigDiffy extends Command {
     (r: GenericRecord) =>  xs.map { x => get(x, 0, r) }.mkString("_")
   }
 
-  private def tableRowKeyFn(keys: Seq[String]): TableRow => String = {
+  private[diffy] def tableRowKeyFn(keys: Seq[String]): TableRow => String = {
     @tailrec
     def get(xs: Array[String], i: Int, r: java.util.Map[String, AnyRef]): String =
       if (i == xs.length - 1) {

--- a/ratatool-examples/src/main/scala/com/spotify/ratatool/examples/diffy/PreProcessBigDiffy.scala
+++ b/ratatool-examples/src/main/scala/com/spotify/ratatool/examples/diffy/PreProcessBigDiffy.scala
@@ -18,14 +18,14 @@
 package com.spotify.ratatool.examples.diffy
 
 import com.spotify.ratatool.avro.specific.ExampleRecord
-import com.spotify.ratatool.diffy.{AvroDiffy, BigDiffy}
+import com.spotify.ratatool.diffy.{AvroDiffy, BigDiffy, MultiKey}
 import com.spotify.scio.ContextAndArgs
 import org.apache.beam.sdk.coders.AvroCoder
 import org.apache.beam.sdk.util.CoderUtils
 
 object PreProcessBigDiffy {
-  def recordKeyFn(r: ExampleRecord): String = {
-    r.getRecordId.toString
+  def recordKeyFn(r: ExampleRecord): MultiKey = {
+    MultiKey(r.getRecordId.toString)
   }
 
   def mapFn(coder: => AvroCoder[ExampleRecord])(r: ExampleRecord): ExampleRecord = {

--- a/ratatool-examples/src/main/scala/com/spotify/ratatool/examples/diffy/ProtobufBigDiffyExample.scala
+++ b/ratatool-examples/src/main/scala/com/spotify/ratatool/examples/diffy/ProtobufBigDiffyExample.scala
@@ -20,14 +20,15 @@ package com.spotify.ratatool.examples.diffy
 import java.net.URI
 
 import com.spotify.ratatool.GcsConfiguration
-import com.spotify.ratatool.diffy.{BigDiffy, ProtoBufDiffy}
+import com.spotify.ratatool.diffy.{BigDiffy, MultiKey, ProtoBufDiffy}
 import com.spotify.ratatool.examples.proto.Schemas.ExampleRecord
 import org.apache.hadoop.fs.{FileSystem, Path}
+
 import com.spotify.scio._
 
 object ProtobufBigDiffyExample {
-  def recordKeyFn(t: ExampleRecord): String = {
-    t.getStringField
+  def recordKeyFn(t: ExampleRecord): MultiKey = {
+    MultiKey(t.getStringField)
   }
 
   def main(cmdlineArgs: Array[String]): Unit = {

--- a/ratatool-shapeless/src/main/scala/com/spotify/ratatool/shapeless/CaseClassDiffy.scala
+++ b/ratatool-shapeless/src/main/scala/com/spotify/ratatool/shapeless/CaseClassDiffy.scala
@@ -18,12 +18,11 @@
 package com.spotify.ratatool.shapeless
 
 import com.spotify.ratatool.Command
-import com.spotify.ratatool.diffy.{BigDiffy, Delta, Diffy}
+import com.spotify.ratatool.diffy.{BigDiffy, Delta, Diffy, MultiKey}
 import com.spotify.ratatool.diffy.BigDiffy.diff
 import com.spotify.scio.values.SCollection
 import shapeless._
 import shapeless.labelled.FieldType
-
 import scala.reflect.ClassTag
 
 @SerialVersionUID(42L)
@@ -173,7 +172,7 @@ object CaseClassDiffy {
   /** Diff two SCollection[T] **/
   def diffCaseClass[T : ClassTag : MapEncoder](lhs: SCollection[T],
                                                rhs: SCollection[T],
-                                               keyFn: T => String,
+                                               keyFn: T => MultiKey,
                                                diffy: CaseClassDiffy[T]) : BigDiffy[T] =
     diff(lhs, rhs, diffy, keyFn)
 }


### PR DESCRIPTION
Addresses #137.
There were two options that I thought about:
1) Join all keys and to get a single String in `*KeyFn` functions.
2) Use the list of string representation of the keys as key to the join.

Decided to go with (1) since we will need to join the keys anyways to write the results.