### PR TITLE
update READMEs and docs to provide correct tempLocation info for Dataflow 2.x

### DIFF
--- a/ratatool-diffy/README.md
+++ b/ratatool-diffy/README.md
@@ -38,8 +38,7 @@ minimum, the following should be specified:
 
    --project=<gcp-project-id>                GCP Project used to run your job
    --runner=DataflowRunner                   Executes the job on Google Cloud Dataflow
-   --stagingLocation=<gcs-path>              Location to stage jars for the job. GCS bucket must be created prior to running job.
-   --gcpTempLocation=<gcs-path>              Location for temporary files. GCS bucket must be created prior to running job.
+   --tempLocation=<gcs-path>                 Location for temporary files. GCS bucket must be created prior to running job.
 
 The following options are recommended, but may not be necessary.
 

--- a/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/BigDiffy.scala
+++ b/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/BigDiffy.scala
@@ -404,8 +404,7 @@ object BigDiffy extends Command {
         |
         |   --project=<gcp-project-id>                GCP Project used to run your job
         |   --runner=DataflowRunner                   Executes the job on Google Cloud Dataflow
-        |   --stagingLocation=<gcs-path>              Location to stage jars for the job. GCS bucket must be created prior to running job.
-        |   --gcpTempLocation=<gcs-path>              Location for temporary files. GCS bucket must be created prior to running job.
+        |   --tempLocation=<gcs-path>                 Location for temporary files. GCS bucket must be created prior to running job.
         |
         |The following options are recommended, but may not be necessary.
         |

--- a/ratatool-sampling/README.md
+++ b/ratatool-sampling/README.md
@@ -32,8 +32,8 @@ minimum, the following should be specified:
 
    --project=<gcp-project-id>                GCP Project used to run your job
    --runner=DataflowRunner                   Executes the job on Google Cloud Dataflow
-   --stagingLocation=<gcs-path>              Location to stage jars for the job. GCS bucket must be created prior to running job.
-   --gcpTempLocation=<gcs-path>              Location for temporary files. GCS bucket must be created prior to running job.
+   --tempLocation=<gcs-path>                 Location for temporary files. GCS bucket must be created prior to running job.
+
 
 The following options are recommended, but may not be necessary.
 

--- a/ratatool-sampling/src/main/scala/com/spotify/ratatool/samplers/BigSampler.scala
+++ b/ratatool-sampling/src/main/scala/com/spotify/ratatool/samplers/BigSampler.scala
@@ -129,8 +129,7 @@ object BigSampler extends Command {
         |
         |   --project=<gcp-project-id>                GCP Project used to run your job
         |   --runner=DataflowRunner                   Executes the job on Google Cloud Dataflow
-        |   --stagingLocation=<gcs-path>              Location to stage jars for the job. GCS bucket must be created prior to running job.
-        |   --gcpTempLocation=<gcs-path>              Location for temporary files. GCS bucket must be created prior to running job.
+        |   --tempLocation=<gcs-path>                 Location for temporary files. GCS bucket must be created prior to running job.
         |
         |The following options are recommended, but may not be necessary.
         |


### PR DESCRIPTION
Nothing else stood out to me in the Dataflow 2 migration guide but if you want you can double check it at https://cloud.google.com/dataflow/docs/guides/migrate-java-1-to-2