### PR TITLE
BigDiffy: Delta is serialized, shouldn't contain nulls

### DIFF
--- a/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/AvroDiffy.scala
+++ b/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/AvroDiffy.scala
@@ -49,7 +49,7 @@ class AvroDiffy[T <: GenericRecord](ignore: Set[String] = Set.empty,
           if (a == null && b == null) {
             Nil
           } else if (a == null || b == null) {
-            Seq(Delta(fullName, a, b, UnknownDelta))
+            Seq(Delta(fullName, Option(a), Option(b), UnknownDelta))
           } else {
             diff(a, b, fullName)
           }
@@ -68,12 +68,12 @@ class AvroDiffy[T <: GenericRecord](ignore: Set[String] = Set.empty,
           else {
             val a = sortList(x.get(name).asInstanceOf[java.util.List[GenericRecord]])
             val b = sortList(y.get(name).asInstanceOf[java.util.List[GenericRecord]])
-            if (a == b) Nil else Seq(Delta(fullName, a, b, delta(a, b)))
+            if (a == b) Nil else Seq(Delta(fullName, Option(a), Option(b), delta(a, b)))
           }
         case _ =>
           val a = x.get(name)
           val b = y.get(name)
-          if (a == b) Nil else Seq(Delta(fullName, a, b, delta(a, b)))
+          if (a == b) Nil else Seq(Delta(fullName, Option(a), Option(b), delta(a, b)))
       }
     }
     .filter(d => !ignore.contains(d.field))

--- a/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/Diffy.scala
+++ b/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/Diffy.scala
@@ -65,7 +65,8 @@ object VectorDelta {
  * @param delta delta of numerical values
  */
 case class Delta(field: String, left: Option[Any], right: Option[Any], delta: DeltaValue) {
-  override def toString: String = s"$field\t$delta\t$left\t$right"
+  override def toString: String = s"$field\t$delta\t" +
+    s"${left.map(_.toString).getOrElse("null")}\t${right.map(_.toString).getOrElse("null")}"
 }
 
 /**

--- a/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/Diffy.scala
+++ b/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/Diffy.scala
@@ -60,11 +60,11 @@ object VectorDelta {
  * Delta of a single field between two records.
  *
  * @param field "." separated field identifier
- * @param left  left hand side value
- * @param right right hand side value
+ * @param left  Option(left hand side value), None if null
+ * @param right Option(right hand side value), None if null
  * @param delta delta of numerical values
  */
-case class Delta(field: String, left: Any, right: Any, delta: DeltaValue) {
+case class Delta(field: String, left: Option[Any], right: Option[Any], delta: DeltaValue) {
   override def toString: String = s"$field\t$delta\t$left\t$right"
 }
 

--- a/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/ProtoBufDiffy.scala
+++ b/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/ProtoBufDiffy.scala
@@ -70,7 +70,7 @@ extends Diffy[T](ignore, unordered, unorderedFieldKeys) {
               case (l, r) => diff(l, r, f.getMessageType.getFields.asScala, fullName)}
         }
         else {
-          if (a == b) Nil else Seq(Delta(fullName, a, b, delta(a, b)))
+          if (a == b) Nil else Seq(Delta(fullName, Option(a), Option(b), delta(a, b)))
         }
       } else {
         f.getJavaType match {
@@ -80,14 +80,14 @@ extends Diffy[T](ignore, unordered, unorderedFieldKeys) {
             if (a == null && b == null) {
               Nil
             } else if (a == null || b == null) {
-              Seq(Delta(fullName, a, b, UnknownDelta))
+              Seq(Delta(fullName, Option(a), Option(b), UnknownDelta))
             } else {
               diff(a, b, f.getMessageType.getFields.asScala, fullName)
             }
           case _ =>
             val a = x.getField(f)
             val b = y.getField(f)
-            if (a == b) Nil else Seq(Delta(fullName, a, b, delta(a, b)))
+            if (a == b) Nil else Seq(Delta(fullName, Option(a), Option(b), delta(a, b)))
         }
       }
     }

--- a/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/TableRowDiffy.scala
+++ b/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/TableRowDiffy.scala
@@ -62,7 +62,7 @@ class TableRowDiffy(tableSchema: TableSchema,
         if (a == null && b == null) {
           Nil
         } else if (a == null || b == null) {
-          Seq(Delta(fullName, a, b, UnknownDelta))
+          Seq(Delta(fullName, Option(a), Option(b), UnknownDelta))
         } else {
           diff(a, b, f.getFields.asScala, fullName)
         }
@@ -80,12 +80,12 @@ class TableRowDiffy(tableSchema: TableSchema,
         else {
           val a = sortList(x.get(name).asInstanceOf[java.util.List[AnyRef]])
           val b = sortList(y.get(name).asInstanceOf[java.util.List[AnyRef]])
-          if (a == b) Nil else Seq(Delta(fullName, a, b, delta(a, b)))
+          if (a == b) Nil else Seq(Delta(fullName, Option(a), Option(b), delta(a, b)))
         }
       } else {
         val a = x.get(name)
         val b = y.get(name)
-        if (a == b) Nil else Seq(Delta(fullName, a, b, delta(a, b)))
+        if (a == b) Nil else Seq(Delta(fullName, Option(a), Option(b), delta(a, b)))
       }
     }
     .filter(d => !ignore.contains(d.field))

--- a/ratatool-diffy/src/test/scala/com/spotify/ratatool/diffy/AvroDiffyTest.scala
+++ b/ratatool-diffy/src/test/scala/com/spotify/ratatool/diffy/AvroDiffyTest.scala
@@ -39,7 +39,7 @@ class AvroDiffyTest extends FlatSpec with Matchers {
 
     d(x, y) should equal (Nil)
     d(x, z) should equal (Seq(
-      Delta("long_field", 20L, 200L, NumericDelta(180.0))))
+      Delta("long_field", Option(20L), Option(200L), NumericDelta(180.0))))
   }
 
   it should "support nested fields" in {
@@ -63,10 +63,11 @@ class AvroDiffyTest extends FlatSpec with Matchers {
 
     d(x, y) should equal (Nil)
     d(x, z1) should equal (Seq(
-      Delta("nullable_nested_field.long_field", 20L, 200L, NumericDelta(180.0)),
-      Delta("nullable_nested_field.string_field", "hello", "Hello", StringDelta(1.0))))
+      Delta("nullable_nested_field.long_field", Option(20L), Option(200L), NumericDelta(180.0)),
+      Delta("nullable_nested_field.string_field", Option("hello"), Option("Hello"), StringDelta
+      (1.0))))
     d(x, z2) should equal (Seq(
-      Delta("nullable_nested_field", nnr, null, UnknownDelta)))
+      Delta("nullable_nested_field", Option(nnr), None, UnknownDelta)))
     d(z2, z3) should equal (Nil)
   }
 
@@ -86,10 +87,11 @@ class AvroDiffyTest extends FlatSpec with Matchers {
 
     d(x, y) should equal (Nil)
     d(x, z) should equal (Seq(
-      Delta("repeated_fields.long_field",
-        jl(20L, 21L), jl(-20L, -21L), VectorDelta(2.0)),
+      Delta("repeated_fields.long_field", Option(jl(20L, 21L)), Option(jl(-20L, -21L)),
+        VectorDelta(2.0)),
       Delta("repeated_fields.string_field",
-        jl("hello", "world"), jl("Hello", "World"), UnknownDelta)))
+        Option(jl("hello", "world")), Option(jl("Hello", "World")),
+        UnknownDelta)))
   }
 
   it should "support ignore" in {
@@ -100,7 +102,7 @@ class AvroDiffyTest extends FlatSpec with Matchers {
     val di = new AvroDiffy[GenericRecord](Set("int_field"))
     di(x, y) should equal (Nil)
     di(x, z) should equal (Seq(
-      Delta("long_field", 20L, 200L, NumericDelta(180.0))))
+      Delta("long_field", Option(20L), Option(200L), NumericDelta(180.0))))
   }
 
   it should "support unordered" in {
@@ -120,7 +122,7 @@ class AvroDiffyTest extends FlatSpec with Matchers {
     du(x, y) should equal (Nil)
     du(x, z) should equal (Nil)
     d(x, z) should equal (Seq(
-      Delta("repeated_nested_field", jl(a, b, c), jl(a, c, b), UnknownDelta)))
+      Delta("repeated_nested_field", Option(jl(a, b, c)), Option(jl(a, c, b)), UnknownDelta)))
   }
 
   it should "support unordered nested" in {
@@ -148,10 +150,6 @@ class AvroDiffyTest extends FlatSpec with Matchers {
     du(x, y) should equal (Nil)
     du(x, z) should equal (Nil)
     d(x, z) should equal (Seq(
-      Delta(
-        "repeated_record",
-        jl(a, b, c),
-        jl(a, c, b),
-        UnknownDelta)))
+      Delta("repeated_record", Option(jl(a, b, c)), Option(jl(a, c, b)), UnknownDelta)))
   }
 }

--- a/ratatool-diffy/src/test/scala/com/spotify/ratatool/diffy/BigDiffyTest.scala
+++ b/ratatool-diffy/src/test/scala/com/spotify/ratatool/diffy/BigDiffyTest.scala
@@ -77,8 +77,8 @@ class BigDiffyTest extends PipelineSpec {
       result.deltas.map(d => (d._1, d._2)) should containInAnyOrder (
         keys.map((_, field)))
       result.keyStats should containInAnyOrder (keyedDoubles.map { case (k, d) =>
-        KeyStats(k, DiffType.DIFFERENT, Option(Delta("required_fields.double_field", d, d + 10.0,
-          TypedDelta(DeltaType.NUMERIC, 10.0))))})
+        KeyStats(k, DiffType.DIFFERENT, Option(Delta("required_fields.double_field", Option(d),
+          Option(d + 10.0), TypedDelta(DeltaType.NUMERIC, 10.0))))})
       result.fieldStats.map(f => (f.field, f.count, f.fraction)) should containSingleValue (
         (field, 1000L, 1.0))
       // Double.NaN comparison is always false

--- a/ratatool-diffy/src/test/scala/com/spotify/ratatool/diffy/ProtoBufDiffyTest.scala
+++ b/ratatool-diffy/src/test/scala/com/spotify/ratatool/diffy/ProtoBufDiffyTest.scala
@@ -35,7 +35,7 @@ class ProtoBufDiffyTest extends FlatSpec with Matchers {
     val d = new ProtoBufDiffy[OptionalNestedRecord]()
     d(x, y) should equal (Nil)
     d(x, z) should equal (Seq(
-      Delta("int64_field", 20L, 200L, NumericDelta(180.0))))
+      Delta("int64_field", Option(20L), Option(200L), NumericDelta(180.0))))
   }
 
   it should "support nested fields" in {
@@ -63,10 +63,11 @@ class ProtoBufDiffyTest extends FlatSpec with Matchers {
     val d = new ProtoBufDiffy[TestRecord]()
     d(x, y) should equal (Nil)
     d(x, z1) should equal (Seq(
-      Delta("optional_nested_field.int64_field", 20L, 200L, NumericDelta(180.0)),
-      Delta("optional_nested_field.string_field", "hello", "Hello", StringDelta(1.0))))
+      Delta("optional_nested_field.int64_field", Option(20L), Option(200L), NumericDelta(180.0)),
+      Delta("optional_nested_field.string_field", Option("hello"), Option("Hello"),
+        StringDelta(1.0))))
     d(x, z2) should equal (Seq(
-      Delta("optional_nested_field", onr, null, UnknownDelta)))
+      Delta("optional_nested_field", Option(onr), None, UnknownDelta)))
     d(z2, z3) should equal (Nil)
   }
 
@@ -97,10 +98,10 @@ class ProtoBufDiffyTest extends FlatSpec with Matchers {
     val d = new ProtoBufDiffy[TestRecord]()
     d(x, y) should equal (Nil)
     d(x, z) should equal (Seq(
-      Delta("repeated_fields.int64_field",
-        jl(20L, 21L), jl(-20L, -21L), VectorDelta(2.0)),
-      Delta("repeated_fields.string_field",
-        jl("hello", "world"), jl("Hello", "World"), UnknownDelta)))
+      Delta("repeated_fields.int64_field", Option(jl(20L, 21L)), Option(jl(-20L, -21L)),
+        VectorDelta(2.0)),
+      Delta("repeated_fields.string_field", Option(jl("hello", "world")),
+        Option(jl("Hello", "World")), UnknownDelta)))
   }
 
   it should "support ignore" in {
@@ -111,7 +112,7 @@ class ProtoBufDiffyTest extends FlatSpec with Matchers {
     val di = new ProtoBufDiffy[OptionalNestedRecord](Set("int32_field"))
     di(x, y) should equal (Nil)
     di(x, z) should equal (Seq(
-      Delta("int64_field", 20L, 200L, NumericDelta(180.0))))
+      Delta("int64_field", Option(20L), Option(200L), NumericDelta(180.0))))
   }
 
   it should "support unordered" in {
@@ -138,7 +139,7 @@ class ProtoBufDiffyTest extends FlatSpec with Matchers {
     du(x, z) should equal (Nil)
     val d = new ProtoBufDiffy[TestRecord]
     d(x, z) should equal (Seq(
-      Delta("repeated_nested_field", jl(a, b, c), jl(a, c, b), UnknownDelta)))
+      Delta("repeated_nested_field", Option(jl(a, b, c)), Option(jl(a, c, b)), UnknownDelta)))
   }
 
   it should "support unordered nested" in {
@@ -164,10 +165,6 @@ class ProtoBufDiffyTest extends FlatSpec with Matchers {
     du(x, y) should equal (Nil)
     du(x, z) should equal (Nil)
     d(x, z) should equal (Seq(
-      Delta(
-        "repeated_record",
-        jl(a, b, c),
-        jl(a, c, b),
-        UnknownDelta)))
+      Delta("repeated_record", Option(jl(a, b, c)), Option(jl(a, c, b)), UnknownDelta)))
   }
 }

--- a/ratatool-diffy/src/test/scala/com/spotify/ratatool/diffy/TableRowDiffyTest.scala
+++ b/ratatool-diffy/src/test/scala/com/spotify/ratatool/diffy/TableRowDiffyTest.scala
@@ -38,8 +38,8 @@ class TableRowDiffyTest extends FlatSpec with Matchers {
     val d = new TableRowDiffy(schema)
     d(x, y) should equal (Nil)
     d(x, z) should equal (Seq(
-      Delta("field2", 20, 200, NumericDelta(180.0)),
-      Delta("field3", 30, 300, NumericDelta(270.0))))
+      Delta("field2", Option(20), Option(200), NumericDelta(180.0)),
+      Delta("field3", Option(30), Option(300), NumericDelta(270.0))))
   }
 
   it should "support nested fields" in {
@@ -60,10 +60,10 @@ class TableRowDiffyTest extends FlatSpec with Matchers {
     val d = new TableRowDiffy(schema)
     d(x, y) should equal (Nil)
     d(x, z1) should equal (Seq(
-      Delta("field1.field1b", 20, 200, NumericDelta(180.0)),
-      Delta("field1.field1c", "hello", "Hello", StringDelta(1.0))))
+      Delta("field1.field1b", Option(20), Option(200), NumericDelta(180.0)),
+      Delta("field1.field1c", Option("hello"), Option("Hello"), StringDelta(1.0))))
     d(x, z2) should equal (Seq(
-      Delta("field1", x.get("field1"), null, UnknownDelta)))
+      Delta("field1", Option(x.get("field1")), None, UnknownDelta)))
     d(z2, z3) should equal (Nil)
   }
 
@@ -82,8 +82,8 @@ class TableRowDiffyTest extends FlatSpec with Matchers {
     val d = new TableRowDiffy(schema)
     d(x, y) should equal (Nil)
     d(x, z) should equal (Seq(
-      Delta("field2", jl(20, 21), jl(-20, -21), VectorDelta(2.0)),
-      Delta("field3", jl("hello", "world"), jl("Hello", "World"), UnknownDelta)))
+      Delta("field2", Option(jl(20, 21)), Option(jl(-20, -21)), VectorDelta(2.0)),
+      Delta("field3", Option(jl("hello", "world")), Option(jl("Hello", "World")), UnknownDelta)))
   }
 
   it should "support ignore" in {
@@ -98,8 +98,8 @@ class TableRowDiffyTest extends FlatSpec with Matchers {
     val di = new TableRowDiffy(schema, Set("field1"))
     di(x, y) should equal (Nil)
     di(x, z) should equal (Seq(
-      Delta("field2", 20, 200, NumericDelta(180.0)),
-      Delta("field3", 30, 300, NumericDelta(270.0))))
+      Delta("field2", Option(20), Option(200), NumericDelta(180.0)),
+      Delta("field3", Option(30), Option(300), NumericDelta(270.0))))
   }
 
   it should "support unordered" in {
@@ -122,7 +122,7 @@ class TableRowDiffyTest extends FlatSpec with Matchers {
     du(x, z) should equal (Nil)
     val d = new TableRowDiffy(schema)
     d(x, z) should equal (Seq(
-      Delta("field1", jl(a, b, c), jl(a, c, b), UnknownDelta)))
+      Delta("field1", Option(jl(a, b, c)), Option(jl(a, c, b)), UnknownDelta)))
   }
 
   it should "support unordered nested" in {
@@ -166,10 +166,6 @@ class TableRowDiffyTest extends FlatSpec with Matchers {
     du(x, y) should equal (Nil)
     du(x, z) should equal (Nil)
     d(x, z) should equal (Seq(
-      Delta(
-        "repeated_record",
-        jl(a, b, c),
-        jl(a, c, b),
-        UnknownDelta)))
+      Delta("repeated_record", Option(jl(a, b, c)), Option(jl(a, c, b)), UnknownDelta)))
   }
 }

--- a/ratatool-shapeless/src/main/scala/com/spotify/ratatool/shapeless/CaseClassDiffy.scala
+++ b/ratatool-shapeless/src/main/scala/com/spotify/ratatool/shapeless/CaseClassDiffy.scala
@@ -162,7 +162,7 @@ class CaseClassDiffy[T](ignore: Set[String] = Set.empty,
 
     (left, right) match {
       case (Some(l: Map[String, Any]), Some(r: Map[String, Any])) => diffMap(l, r, pref)
-      case (Some(l), Some(r)) => Seq(Delta(pref, l, r, delta(l, r)))
+      case (Some(l), Some(r)) => Seq(Delta(pref, Option(l), Option(r), delta(l, r)))
     }
   }
 }

--- a/ratatool-shapeless/src/test/scala/com/spotify/ratatool/shapeless/CaseClassDiffyTest.scala
+++ b/ratatool-shapeless/src/test/scala/com/spotify/ratatool/shapeless/CaseClassDiffyTest.scala
@@ -40,40 +40,42 @@ class CaseClassDiffyTest extends FlatSpec with Matchers {
   "CaseClassDiffy" should "support primitive fields" in {
     val result = dFoo.apply(f1, f2)
 
-    result should contain (Delta("f1", "foo1", "foo2", StringDelta(1.0)))
-    result should contain (Delta("f2", 1, 1, NumericDelta(0.0)))
-    result should contain (Delta("f3", 3,3, NumericDelta(0.0)))
-    result should contain (Delta("f5", Vector("foo1"), Vector("foo2"), UnknownDelta))
+    result should contain (Delta("f1", Option("foo1"), Option("foo2"), StringDelta(1.0)))
+    result should contain (Delta("f2", Option(1), Option(1), NumericDelta(0.0)))
+    result should contain (Delta("f3", Option(3), Option(3), NumericDelta(0.0)))
+    result should contain (Delta("f5", Option(Vector("foo1")), Option(Vector("foo2")),
+      UnknownDelta))
   }
 
   "CaseClassDiffy" should "support nested fields" in {
     val result = dBar.apply(b1, b2)
 
-    result should contain (Delta("b1", 1, 2, NumericDelta(1.0)))
-    result should contain (Delta("b2.f1", "foo1", "foo2", StringDelta(1.0)))
-    result should contain (Delta("b2.f2", 1, 1, NumericDelta(0.0)))
-    result should contain (Delta("b2.f3", 3,3, NumericDelta(0.0)))
+    result should contain (Delta("b1", Option(1), Option(2), NumericDelta(1.0)))
+    result should contain (Delta("b2.f1", Option("foo1"), Option("foo2"), StringDelta(1.0)))
+    result should contain (Delta("b2.f2", Option(1), Option(1), NumericDelta(0.0)))
+    result should contain (Delta("b2.f3", Option(3), Option(3), NumericDelta(0.0)))
     result should contain
-      (Delta("b2.f5", Vector("foo1"), Vector("foo2"), UnknownDelta))
+      (Delta("b2.f5", Option(Vector("foo1")), Option(Vector("foo2")), UnknownDelta))
   }
 
   "CaseClassDiffy" should "support ignore with exact match case" in {
     val result = dFooWithIgnore.apply(f1, f2)
     result.map(_.field) shouldNot contain ("f2")
 
-    result should contain (Delta("f1", "foo1", "foo2", StringDelta(1.0)))
-    result should contain (Delta("f3", 3,3, NumericDelta(0.0)))
-    result should contain (Delta("f5", Vector("foo1"), Vector("foo2"), UnknownDelta))
+    result should contain (Delta("f1", Option("foo1"), Option("foo2"), StringDelta(1.0)))
+    result should contain (Delta("f3", Option(3), Option(3), NumericDelta(0.0)))
+    result should contain (Delta("f5", Option(Vector("foo1")), Option(Vector("foo2")),
+      UnknownDelta))
   }
 
   "CaseClassDiffy" should "support ignore with nested field case" in {
     val result = dBarWithIgnore.apply(b1, b2)
     result.map(_.field) shouldNot contain ("f2")
 
-    result should contain (Delta("b1", 1, 2, NumericDelta(1.0)))
-    result should contain (Delta("b2.f1", "foo1", "foo2", StringDelta(1.0)))
-    result should contain (Delta("b2.f3", 3,3, NumericDelta(0.0)))
+    result should contain (Delta("b1", Option(1), Option(2), NumericDelta(1.0)))
+    result should contain (Delta("b2.f1", Option("foo1"), Option("foo2"), StringDelta(1.0)))
+    result should contain (Delta("b2.f3", Option(3), Option(3), NumericDelta(0.0)))
     result should contain
-    (Delta("b2.f5", Vector("foo1"), Vector("foo2"), UnknownDelta))
+    (Delta("b2.f5", Option(Vector("foo1")), Option(Vector("foo2")), UnknownDelta))
   }
 }


### PR DESCRIPTION
Change Delta case class to store LHS and RHS as Options, so we're not shuffling around and eventually saving a null value when one half of the diff is null

This solves an NPE which occurs in Dataflow when diffing two fields, one of which is null and one of which isn't. The NPE occurs at the end of the pipeline, when trying to write diff results to BigQuery. The exception's trace contains `Caused by: org.apache.beam.sdk.coders.CoderException: cannot encode a null value`. 

Fixes https://github.com/spotify/ratatool/issues/152 