### PR TITLE
Assert that schema is backwards compatible for Avro

### DIFF
--- a/ratatool-common/src/test/resources/EvolvedSimpleRecord.avsc
+++ b/ratatool-common/src/test/resources/EvolvedSimpleRecord.avsc
@@ -1,0 +1,35 @@
+{
+    "type": "record",
+    "name": "SimpleRecord",
+    "namespace": "com.spotify.ratatool.avro.generic",
+    "doc": "Record for testing",
+    "fields": [
+        {
+            "name": "nullable_fields",
+            "type": {
+                "type": "record",
+                "name": "SimpleNullableNestedRecord",
+                "namespace": "com.spotify.ratatool.avro.generic",
+                "doc": "Record for testing",
+                "fields": [
+                    {"name": "int_field", "type": ["null", "int"], "default": null},
+                    {"name": "long_field", "type": ["null", "long"], "default": null},
+                    {"name": "string_field", "type": ["null", "string"], "default": null}
+                ]
+            }
+        },
+        {
+            "name": "required_fields",
+            "type": {
+                "type": "record",
+                "name": "SimpleRequiredNestedRecord",
+                "namespace": "com.spotify.ratatool.avro.generic",
+                "doc": "Record for testing",
+                "fields": [
+                    {"name": "boolean_field", "type": "boolean"},
+                    {"name": "string_field", "type": "string"}
+                ]
+            }
+        }
+    ]
+}

--- a/ratatool-common/src/test/resources/SimpleRecord.avsc
+++ b/ratatool-common/src/test/resources/SimpleRecord.avsc
@@ -1,0 +1,34 @@
+{
+    "type": "record",
+    "name": "SimpleRecord",
+    "namespace": "com.spotify.ratatool.avro.generic",
+    "doc": "Record for testing",
+    "fields": [
+        {
+            "name": "nullable_fields",
+            "type": {
+                "type": "record",
+                "name": "SimpleNullableNestedRecord",
+                "namespace": "com.spotify.ratatool.avro.generic",
+                "doc": "Record for testing",
+                "fields": [
+                    {"name": "int_field", "type": ["null", "int"], "default": null},
+                    {"name": "long_field", "type": ["null", "long"], "default": null}
+                ]
+            }
+        },
+        {
+            "name": "required_fields",
+            "type": {
+                "type": "record",
+                "name": "SimpleRequiredNestedRecord",
+                "namespace": "com.spotify.ratatool.avro.generic",
+                "doc": "Record for testing",
+                "fields": [
+                    {"name": "boolean_field", "type": "boolean"},
+                    {"name": "string_field", "type": "string"}
+                ]
+            }
+        }
+    ]
+}

--- a/ratatool-common/src/test/scala/com/spotify/ratatool/Schemas.scala
+++ b/ratatool-common/src/test/scala/com/spotify/ratatool/Schemas.scala
@@ -25,9 +25,14 @@ import org.apache.avro.Schema
 
 object Schemas {
 
-  val avroSchema = new Schema.Parser().parse(this.getClass.getResourceAsStream("/schema.avsc"))
+  val avroSchema: Schema =
+    new Schema.Parser().parse(this.getClass.getResourceAsStream("/schema.avsc"))
+  val simpleAvroSchema: Schema =
+    new Schema.Parser().parse(this.getClass.getResourceAsStream("/SimpleRecord.avsc"))
+  val evolvedSimpleAvroSchema: Schema =
+    new Schema.Parser().parse(this.getClass.getResourceAsStream("/EvolvedSimpleRecord.avsc"))
 
-  val tableSchema = new JsonObjectParser(new JacksonFactory)
+  val tableSchema: TableSchema = new JsonObjectParser(new JacksonFactory)
     .parseAndClose(
       this.getClass.getResourceAsStream("/schema.json"),
       Charsets.UTF_8,

--- a/ratatool-diffy/README.md
+++ b/ratatool-diffy/README.md
@@ -55,3 +55,10 @@ libraryDependencies += "com.spotify" %% "ratatool-diffy" % ratatoolVersion
 
 ```
 The latest version can be found in the main [README](https://github.com/spotify/ratatool/blob/master/README.md).
+
+## Schema Evolution
+If you are trying to diff two schemas that are backwards compatible, you should put the "new" schema
+ which is backwards compatible on the RHS. You can also add the new fields to the ignore list to
+ prune them from the diff results. For BigQuery, the diff is applied across the union of the two
+ schemas. For Avro, the RHS is used as the source of truth, and the diff is assumed to apply to all
+ fields in the RHS unless it is specified in `ignore`.

--- a/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/AvroDiffy.scala
+++ b/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/AvroDiffy.scala
@@ -40,7 +40,7 @@ class AvroDiffy[T <: GenericRecord](ignore: Set[String] = Set.empty,
       x.get(f)
     }
 
-    x.getSchema.getFields.asScala.flatMap { f =>
+    y.getSchema.getFields.asScala.flatMap { f =>
       val name = f.name()
       val fullName = if (root.isEmpty) name else root + "." + name
       getRawType(f.schema()).getType match {

--- a/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/AvroDiffy.scala
+++ b/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/AvroDiffy.scala
@@ -17,7 +17,7 @@
 
 package com.spotify.ratatool.diffy
 
-import org.apache.avro.Schema
+import org.apache.avro.{Schema, SchemaValidatorBuilder}
 import org.apache.avro.generic.GenericRecord
 
 import scala.collection.JavaConverters._
@@ -29,6 +29,8 @@ class AvroDiffy[T <: GenericRecord](ignore: Set[String] = Set.empty,
   extends Diffy[T](ignore, unordered, unorderedFieldKeys) {
 
   override def apply(x: T, y: T): Seq[Delta] = {
+    new SchemaValidatorBuilder().canReadStrategy.validateLatest()
+      .validate(y.getSchema, List(x.getSchema).asJava)
     diff(x, y, "")
   }
 

--- a/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/AvroDiffy.scala
+++ b/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/AvroDiffy.scala
@@ -29,7 +29,6 @@ class AvroDiffy[T <: GenericRecord](ignore: Set[String] = Set.empty,
   extends Diffy[T](ignore, unordered, unorderedFieldKeys) {
 
   override def apply(x: T, y: T): Seq[Delta] = {
-    require(x.getSchema == y.getSchema)
     diff(x, y, "")
   }
 

--- a/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/BigDiffy.scala
+++ b/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/BigDiffy.scala
@@ -28,6 +28,7 @@ import com.spotify.scio.values.SCollection
 import com.spotify.scio.coders.Coder
 import com.twitter.algebird._
 import org.apache.avro.Schema
+import org.apache.avro.SchemaValidatorBuilder
 import org.apache.avro.generic.GenericRecord
 import org.apache.beam.sdk.io.TextIO
 
@@ -489,11 +490,14 @@ object BigDiffy extends Command {
 
     val result = inputMode match {
       case "avro" =>
-        // TODO: handle schema
-        val schema = new AvroSampler(rhs, conf = Some(sc.options))
+        val schemaRhs = new AvroSampler(rhs, conf = Some(sc.options))
           .sample(1, head = true).head.getSchema
+        val schemaLhs = new AvroSampler(lhs, conf = Some(sc.options))
+          .sample(1, head = true).head.getSchema
+        new SchemaValidatorBuilder().canReadStrategy.validateLatest()
+          .validate(schemaRhs, Seq(schemaLhs).toList.asJava)
         val diffy = new AvroDiffy[GenericRecord](ignore, unordered)
-        BigDiffy.diffAvro[GenericRecord](sc, lhs, rhs, avroKeyFn(keys), diffy, schema)
+        BigDiffy.diffAvro[GenericRecord](sc, lhs, rhs, avroKeyFn(keys), diffy, schemaRhs)
       case "bigquery" =>
         // TODO: handle schema evolution
         val bq = BigQuery.defaultInstance()

--- a/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/BigDiffy.scala
+++ b/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/BigDiffy.scala
@@ -490,14 +490,10 @@ object BigDiffy extends Command {
 
     val result = inputMode match {
       case "avro" =>
-        val schemaRhs = new AvroSampler(rhs, conf = Some(sc.options))
+        val schema = new AvroSampler(rhs, conf = Some(sc.options))
           .sample(1, head = true).head.getSchema
-        val schemaLhs = new AvroSampler(lhs, conf = Some(sc.options))
-          .sample(1, head = true).head.getSchema
-        new SchemaValidatorBuilder().canReadStrategy.validateLatest()
-          .validate(schemaRhs, Seq(schemaLhs).toList.asJava)
         val diffy = new AvroDiffy[GenericRecord](ignore, unordered)
-        BigDiffy.diffAvro[GenericRecord](sc, lhs, rhs, avroKeyFn(keys), diffy, schemaRhs)
+        BigDiffy.diffAvro[GenericRecord](sc, lhs, rhs, avroKeyFn(keys), diffy, schema)
       case "bigquery" =>
         // TODO: handle schema evolution
         val bq = BigQuery.defaultInstance()

--- a/ratatool-diffy/src/test/scala/com/spotify/ratatool/diffy/AvroDiffyTest.scala
+++ b/ratatool-diffy/src/test/scala/com/spotify/ratatool/diffy/AvroDiffyTest.scala
@@ -190,9 +190,9 @@ class AvroDiffyTest extends FlatSpec with Matchers {
     d(y, x) should equal(Seq(
       Delta(
         "nullable_fields.string_field",
-        null,
-        x.get("nullable_fields").asInstanceOf[GenericRecord].get("string_field")
-          .asInstanceOf[String],
+        None,
+        Option(x.get("nullable_fields").asInstanceOf[GenericRecord].get("string_field")
+          .asInstanceOf[String]),
         UnknownDelta
       )
     ))

--- a/ratatool-diffy/src/test/scala/com/spotify/ratatool/diffy/AvroDiffyTest.scala
+++ b/ratatool-diffy/src/test/scala/com/spotify/ratatool/diffy/AvroDiffyTest.scala
@@ -17,11 +17,14 @@
 
 package com.spotify.ratatool.diffy
 
+import com.spotify.ratatool.Schemas
 import com.spotify.ratatool.avro.specific._
+import com.spotify.ratatool.diffy.BigDiffy.DeltaValueBigQuery
 import com.spotify.ratatool.scalacheck._
-import org.apache.avro.generic.GenericRecord
+import org.apache.avro.generic.{GenericRecord, GenericRecordBuilder}
 import org.apache.beam.sdk.coders.AvroCoder
 import org.apache.beam.sdk.util.CoderUtils
+import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.{FlatSpec, Matchers}
 
 import scala.collection.JavaConverters._
@@ -153,5 +156,47 @@ class AvroDiffyTest extends FlatSpec with Matchers {
         jl(a, b, c),
         jl(a, c, b),
         UnknownDelta)))
+  }
+
+  it should "support schema evolution if ignored" in {
+    val inner = avroOf(Schemas.evolvedSimpleAvroSchema.getField("nullable_fields").schema())
+        .flatMap(r => Arbitrary.arbString.arbitrary.map { s =>
+          r.put("string_field", s)
+          r
+        })
+    val x = avroOf(Schemas.evolvedSimpleAvroSchema).flatMap(r => inner.map { i =>
+      r.put("nullable_fields", i)
+      r
+    }).sample.get
+    val y = new GenericRecordBuilder(Schemas.simpleAvroSchema)
+      .set(
+        "nullable_fields",
+        new GenericRecordBuilder(Schemas.simpleAvroSchema.getField("nullable_fields").schema())
+          .set("int_field", x.get("nullable_fields").asInstanceOf[GenericRecord].get("int_field"))
+          .set("long_field", x.get("nullable_fields").asInstanceOf[GenericRecord].get("long_field"))
+          .build()
+      )
+      .set(
+        "required_fields",
+        new GenericRecordBuilder(Schemas.simpleAvroSchema.getField("required_fields").schema())
+          .set("boolean_field",
+            x.get("required_fields").asInstanceOf[GenericRecord].get("boolean_field"))
+          .set("string_field",
+            x.get("required_fields").asInstanceOf[GenericRecord].get("string_field"))
+          .build()
+      ).build()
+
+    val d = new AvroDiffy[GenericRecord]()
+    val di = new AvroDiffy[GenericRecord](ignore = Set("nullable_fields.string_field"))
+    di(x, y) should equal (Nil)
+    d(x, y) should equal(Seq(
+      Delta(
+        "nullable_fields.string_field",
+        null,
+        x.get("nullable_fields").asInstanceOf[GenericRecord].get("string_field")
+          .asInstanceOf[String],
+        UnknownDelta
+      )
+    ))
   }
 }

--- a/ratatool-diffy/src/test/scala/com/spotify/ratatool/diffy/AvroDiffyTest.scala
+++ b/ratatool-diffy/src/test/scala/com/spotify/ratatool/diffy/AvroDiffyTest.scala
@@ -188,8 +188,8 @@ class AvroDiffyTest extends FlatSpec with Matchers {
 
     val d = new AvroDiffy[GenericRecord]()
     val di = new AvroDiffy[GenericRecord](ignore = Set("nullable_fields.string_field"))
-    di(x, y) should equal (Nil)
-    d(x, y) should equal(Seq(
+    di(y, x) should equal (Nil)
+    d(y, x) should equal(Seq(
       Delta(
         "nullable_fields.string_field",
         null,


### PR DESCRIPTION
Related to #146 

This assumes that the RHS schema is the "new" schema (backwards compatible to LHS). I also moved this outside of AvroDiffy.

Need to add some tests and docs but curious to hear thoughts on this
