### PR TITLE
Add previously-undeclared dependency on Guava

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -98,8 +98,9 @@ lazy val ratatoolCommon = project
       "org.apache.avro" % "avro" % avroVersion classifier("tests"),
       "org.apache.avro" % "avro-mapred" % avroVersion classifier("hadoop2"),
       "org.slf4j" % "slf4j-simple" % slf4jVersion,
-      "com.google.apis" % "google-api-services-bigquery" % bigqueryVersion % "provided"
-    ),
+      "com.google.apis" % "google-api-services-bigquery" % bigqueryVersion % "provided",
+      "com.google.guava" % "guava" % guavaVersion
+    ), 
     // In case of scalacheck failures print more info
     testOptions in Test += Tests.Argument(TestFrameworks.ScalaCheck, "-verbosity", "3")
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,6 +6,7 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2-1")
 addSbtPlugin("org.scalastyle" % "scalastyle-sbt-plugin" % "1.0.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.4")
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
 
 libraryDependencies ++= Seq(
   "com.github.os72" % "protoc-jar" % "3.6.0.1"


### PR DESCRIPTION
We already had this dependency (see https://github.com/spotify/ratatool/blob/master/ratatool-scalacheck/src/main/scala/com/spotify/ratatool/scalacheck/ProtoBufGenerator.scala#L23) and it wasn't declared, causing trouble for downstreams that didn't already depend on Guava. 

Also added a plugin to visualize dependencies :)

Fixes https://github.com/spotify/ratatool/issues/153