### PR TITLE
Fix BigSampler NPE

### DIFF
--- a/ratatool-sampling/src/main/scala/com/spotify/ratatool/samplers/BigSampler.scala
+++ b/ratatool-sampling/src/main/scala/com/spotify/ratatool/samplers/BigSampler.scala
@@ -360,7 +360,6 @@ object BigSampler extends Command {
   def run(argv: Array[String]): Unit = {
     this.singleInput(argv)
   }
-
 }
 
 

--- a/ratatool-sampling/src/main/scala/com/spotify/ratatool/samplers/BigSampler.scala
+++ b/ratatool-sampling/src/main/scala/com/spotify/ratatool/samplers/BigSampler.scala
@@ -361,8 +361,6 @@ object BigSampler extends Command {
     this.singleInput(argv)
   }
 
-  /** makes it easier to test this in SBT and in JobTests */
-  def main(argv: Array[String]): Unit = run(argv)
 }
 
 

--- a/ratatool-sampling/src/main/scala/com/spotify/ratatool/samplers/BigSampler.scala
+++ b/ratatool-sampling/src/main/scala/com/spotify/ratatool/samplers/BigSampler.scala
@@ -268,7 +268,7 @@ object BigSampler extends Command {
    * @param distributionFields Fields to construct distribution over (strata = set of unique fields)
    * @param precision Approximate or Exact precision
    * @param hashFn Function to construct a hash given a record, field, and hasher
-   * @param keyFn Function to extract a value given a record
+   * @param keyFn Function to extract a value that's safe to serialize and key on, given a record
    * @param maxKeySize Maximum allowed size per key (can be tweaked for very large data sets)
    * @param byteEncoding Determines how bytes are encoded prior to hashing.
    * @tparam T Record Type
@@ -360,6 +360,9 @@ object BigSampler extends Command {
   def run(argv: Array[String]): Unit = {
     this.singleInput(argv)
   }
+
+  /** makes it easier to test this in SBT and in JobTests */
+  def main(argv: Array[String]): Unit = run(argv)
 }
 
 

--- a/ratatool-sampling/src/main/scala/com/spotify/ratatool/samplers/BigSamplerAvro.scala
+++ b/ratatool-sampling/src/main/scala/com/spotify/ratatool/samplers/BigSamplerAvro.scala
@@ -70,12 +70,13 @@ private[samplers] object BigSamplerAvro {
                                  distributionFields: Seq[String])(gr: GenericRecord)
   : Set[Any] = {
     distributionFields.map{f =>
-      val field = getAvroField(gr, f.split(BigSampler.fieldSep).toList, schema)
+      val fieldValue = getAvroField(gr, f.split(BigSampler.fieldSep).toList, schema)
       // Avro caches toString in the Utf8 class which results in an IllegalMutationException
       // later on if we don't materialize the string once before. Ignoring this prevents us
       // from printing the key in e.g. SamplerSCollectionFunctions.logDistributionDiffs.
-      field.toString
-      field
+      // Of course, if it's null we can't call toString on it, so we wrap.
+      Option(fieldValue).map(_.toString)
+      fieldValue
     }.toSet
   }
 

--- a/ratatool-sampling/src/main/scala/com/spotify/ratatool/samplers/BigSamplerBigQuery.scala
+++ b/ratatool-sampling/src/main/scala/com/spotify/ratatool/samplers/BigSamplerBigQuery.scala
@@ -120,10 +120,11 @@ private[samplers] object BigSamplerBigQuery {
 
   private[samplers] def buildKey(schema: => Seq[TableFieldSchema],
                                  distributionFields: Seq[String])(tr: TableRow)
-  : Set[Any] = {
+  : Set[String] = {
     distributionFields.map{ f =>
       getTableRowField(tr, f, schema)
-    }.toSet
+    }
+      .map(_.toString).toSet
   }
 
   //scalastyle:off method.length cyclomatic.complexity parameter.number

--- a/ratatool-sampling/src/main/scala/com/spotify/ratatool/samplers/BigSamplerBigQuery.scala
+++ b/ratatool-sampling/src/main/scala/com/spotify/ratatool/samplers/BigSamplerBigQuery.scala
@@ -123,8 +123,7 @@ private[samplers] object BigSamplerBigQuery {
   : Set[String] = {
     distributionFields.map{ f =>
       getTableRowField(tr, f, schema)
-    }
-      .map(_.toString).toSet
+    }.map(_.toString).toSet
   }
 
   //scalastyle:off method.length cyclomatic.complexity parameter.number

--- a/ratatool-sampling/src/test/scala/com/spotify/ratatool/samplers/BigSamplerAvroTest.scala
+++ b/ratatool-sampling/src/test/scala/com/spotify/ratatool/samplers/BigSamplerAvroTest.scala
@@ -35,7 +35,7 @@ class BigSamplerAvroTest extends PipelineSpec {
         .amend(Gen.const(null))(_.setStringField))(_.setNullableFields)
       .sample.get
 
-    BigSamplerAvro.buildKey(schema, fields)(record) shouldBe Set(null)
+    BigSamplerAvro.buildKey(schema, fields)(record) shouldBe Set("null")
   }
 
 }

--- a/ratatool-sampling/src/test/scala/com/spotify/ratatool/samplers/BigSamplerAvroTest.scala
+++ b/ratatool-sampling/src/test/scala/com/spotify/ratatool/samplers/BigSamplerAvroTest.scala
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2019 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.spotify.ratatool.samplers
 
 import com.spotify.ratatool.Schemas

--- a/ratatool-sampling/src/test/scala/com/spotify/ratatool/samplers/BigSamplerAvroTest.scala
+++ b/ratatool-sampling/src/test/scala/com/spotify/ratatool/samplers/BigSamplerAvroTest.scala
@@ -1,0 +1,24 @@
+package com.spotify.ratatool.samplers
+
+import com.spotify.ratatool.Schemas
+import com.spotify.ratatool.avro.specific.{NullableNestedRecord, TestRecord}
+import com.spotify.scio.testing.PipelineSpec
+import com.spotify.ratatool.scalacheck._
+import org.scalacheck.Gen
+
+class BigSamplerAvroTest extends PipelineSpec {
+
+  "buildKey" should "not throw NPE if field is null" in {
+
+    val schema = Schemas.avroSchema
+    val fields = Seq("nullable_fields.string_field")
+
+    val record = specificRecordOf[TestRecord]
+      .amend(specificRecordOf[NullableNestedRecord]
+        .amend(Gen.const(null))(_.setStringField))(_.setNullableFields)
+      .sample.get
+
+    BigSamplerAvro.buildKey(schema, fields)(record) shouldBe Set(null)
+  }
+
+}


### PR DESCRIPTION
Fixes https://github.com/spotify/ratatool/issues/157

Neville suggested that we avoid trying to serialize `Object`/`Any`/`AnyRef` because we can't serialize those at compile time. Moving the `Set[Any]` key to a `Set[String]` means that we don't even need the nullableCoders fixes in Scio 0.8.0 for it to work :)