### PR TITLE
Allow bigDiffy to work with nullable keys

### DIFF
--- a/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/BigDiffy.scala
+++ b/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/BigDiffy.scala
@@ -429,7 +429,7 @@ object BigDiffy extends Command {
     @tailrec
     def get(xs: Array[String], i: Int, r: GenericRecord): String =
       if (i == xs.length - 1) {
-        r.get(xs(i)).toString
+        String.valueOf(r.get(xs(i)))
       } else {
         get(xs, i + 1, r.get(xs(i)).asInstanceOf[GenericRecord])
       }

--- a/ratatool-diffy/src/test/scala/com/spotify/ratatool/diffy/BigDiffyTest.scala
+++ b/ratatool-diffy/src/test/scala/com/spotify/ratatool/diffy/BigDiffyTest.scala
@@ -120,6 +120,14 @@ class BigDiffyTest extends PipelineSpec {
     }
   }
 
+  "BigDiffy avroKeyFn" should "work with nullable key" in {
+    val record = specificRecordOf[TestRecord].sample.get
+    record.getNullableFields.setIntField(null)
+    val keyValue = BigDiffy.avroKeyFn(Seq("nullable_fields.int_field"))(record)
+
+    keyValue.toString shouldBe "null"
+  }
+
   "BigDiffy avroKeyFn" should "work with single key" in {
     val record = specificRecordOf[TestRecord].sample.get
     val keyValue = BigDiffy.avroKeyFn(Seq("required_fields.int_field"))(record)


### PR DESCRIPTION
Comparing datasets which were grouped by compound key might result in one of the keys having `null` value.

Eg: we have a table grouped by `(company, country, product)` for total number of sales. It's possible that one of the products is `null` as there is no single unique key in this table in order to compare two versions I have to create compound key with `--key=company --key=country --key=product` as `product` might be `null` the unpatched version would throw `NullPointerException`:

```
[ForkJoinPool-1-worker-13] ERROR org.apache.beam.runners.dataflow.util.MonitoringUtil$LoggingHandler - 2019-05-17T14:33:47.344Z: java.lang.NullPointerException
    at com.spotify.ratatool.diffy.BigDiffy$.com$spotify$ratatool$diffy$BigDiffy$$get$1(BigDiffy.scala:428)
    at com.spotify.ratatool.diffy.BigDiffy$$anonfun$avroKeyFn$1$$anonfun$apply$111.apply(BigDiffy.scala:434)
    at com.spotify.ratatool.diffy.BigDiffy$$anonfun$avroKeyFn$1$$anonfun$apply$111.apply(BigDiffy.scala:434)
    at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
    at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
    at scala.collection.immutable.List.foreach(List.scala:392)
    at scala.collection.TraversableLike$class.map(TraversableLike.scala:234)
    at scala.collection.immutable.List.map(List.scala:296)
    at com.spotify.ratatool.diffy.BigDiffy$$anonfun$avroKeyFn$1.apply(BigDiffy.scala:434)
    at com.spotify.ratatool.diffy.BigDiffy$$anonfun$avroKeyFn$1.apply(BigDiffy.scala:434)
    at com.spotify.ratatool.diffy.BigDiffy$$anonfun$63.apply(BigDiffy.scala:183)
    at com.spotify.ratatool.diffy.BigDiffy$$anonfun$63.apply(BigDiffy.scala:183)
    at com.spotify.scio.util.Functions$$anon$7.processElement(Functions.scala:172)
```