### PR TITLE
Warn on null keys

### DIFF
--- a/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/BigDiffy.scala
+++ b/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/BigDiffy.scala
@@ -194,17 +194,18 @@ object BigDiffy extends Command {
     (lKeyed ++ rKeyed)
       .groupByKey
       .map { case (key, values) => // values is a list of tuples: "l" -> record or "r" -> record
+        if (values.size > 2) {
+          throw new RuntimeException(
+            s"""More than two values found for key: $key.
+               | Your key must be unique in both SCollections""".stripMargin)
+        }
+
         val valuesMap = values.toMap // L/R -> record
         if (valuesMap.size == 2) {
           val deltas: Seq[Delta] = diffy(valuesMap("l"), valuesMap("r"))
           val diffType = if (deltas.isEmpty) DiffType.SAME else DiffType.DIFFERENT
           (key, (deltas, diffType))
-        } else if (valuesMap.size > 2) {
-         throw new RuntimeException(
-           s"""More than two values found for key: $key.
-              | Your key must be unique in both SCollections""".stripMargin)
-        }
-        else {
+        } else {
           val diffType = if (valuesMap.contains("l")) DiffType.MISSING_RHS else DiffType.MISSING_LHS
           (key, (Nil, diffType))
         }

--- a/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/BigDiffy.scala
+++ b/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/BigDiffy.scala
@@ -440,7 +440,7 @@ object BigDiffy extends Command {
         if (valueOfKey == null) {
           logger.warn(
             s"""Null value found for key: ${xs.mkString(".")}.
-               | If this is not expected check your or use a different key.""".stripMargin)
+               | If this is not expected check your data or use a different key.""".stripMargin)
         }
         String.valueOf(valueOfKey)
       } else {

--- a/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/BigDiffy.scala
+++ b/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/BigDiffy.scala
@@ -22,25 +22,24 @@ import com.google.protobuf.AbstractMessage
 import com.spotify.ratatool.Command
 import com.spotify.ratatool.samplers.AvroSampler
 import com.spotify.scio._
+import com.spotify.scio.avro._
+import com.spotify.scio.bigquery._
+import com.spotify.scio.bigquery.client.BigQuery
 import com.spotify.scio.bigquery.types.BigQueryType
+import com.spotify.scio.coders.Coder
 import com.spotify.scio.io.Tap
 import com.spotify.scio.values.SCollection
-import com.spotify.scio.coders.Coder
 import com.twitter.algebird._
 import org.apache.avro.Schema
-import org.apache.avro.SchemaValidatorBuilder
 import org.apache.avro.generic.GenericRecord
 import org.apache.beam.sdk.io.TextIO
+import org.slf4j.{Logger, LoggerFactory}
 
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.concurrent.Future
 import scala.reflect.ClassTag
-import com.spotify.scio.avro._
-import com.spotify.scio.bigquery._
-import com.spotify.scio.bigquery.client.BigQuery
-import org.slf4j.{Logger, LoggerFactory}
 
 /**
  * Diff type between two records of the same key.

--- a/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/BigDiffy.scala
+++ b/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/BigDiffy.scala
@@ -440,7 +440,7 @@ object BigDiffy extends Command {
         if (valueOfKey == null) {
           logger.warn(
             s"""Null value found for key: ${xs.mkString(".")}.
-               | If this is not expected check you data or use a different key.""".stripMargin)
+               | If this is not expected check your or use a different key.""".stripMargin)
         }
         String.valueOf(valueOfKey)
       } else {

--- a/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/BigDiffy.scala
+++ b/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/BigDiffy.scala
@@ -199,7 +199,12 @@ object BigDiffy extends Command {
           val deltas: Seq[Delta] = diffy(valuesMap("l"), valuesMap("r"))
           val diffType = if (deltas.isEmpty) DiffType.SAME else DiffType.DIFFERENT
           (key, (deltas, diffType))
-        } else {
+        } else if (valuesMap.size > 2) {
+         throw new RuntimeException(
+           s"""More than two values found for key: $key.
+              | Your key must be unique in both SCollections""".stripMargin)
+        }
+        else {
           val diffType = if (valuesMap.contains("l")) DiffType.MISSING_RHS else DiffType.MISSING_LHS
           (key, (Nil, diffType))
         }

--- a/ratatool-diffy/src/test/scala/com/spotify/ratatool/diffy/BigDiffyTest.scala
+++ b/ratatool-diffy/src/test/scala/com/spotify/ratatool/diffy/BigDiffyTest.scala
@@ -120,7 +120,7 @@ class BigDiffyTest extends PipelineSpec {
     }
   }
 
-  a [RuntimeException] shouldBe thrownBy {
+  a[RuntimeException] shouldBe thrownBy {
     runWithContext { sc =>
       val lhsDuplicate = Gen.listOfN(2, specificGen).sample.get
         .map(r => {

--- a/ratatool-diffy/src/test/scala/com/spotify/ratatool/diffy/BigDiffyTest.scala
+++ b/ratatool-diffy/src/test/scala/com/spotify/ratatool/diffy/BigDiffyTest.scala
@@ -120,6 +120,27 @@ class BigDiffyTest extends PipelineSpec {
     }
   }
 
+  a [RuntimeException] shouldBe thrownBy {
+    runWithContext { sc =>
+      val lhsDuplicate = Gen.listOfN(2, specificGen).sample.get
+        .map(r => {
+          r.getRequiredFields.setIntField(10)
+          r.getRequiredFields.setStringField("key")
+          r
+        })
+      val rhs = Gen.listOfN(1, specificGen).sample.get
+        .map(r => {
+          r.getRequiredFields.setIntField(10)
+          r.getRequiredFields.setStringField("key")
+          r
+        })
+      val result = BigDiffy.diff[TestRecord](
+        sc.parallelize(lhsDuplicate), sc.parallelize(rhs),
+        new AvroDiffy[TestRecord](), x => MultiKey(x.getRequiredFields.getStringField.toString))
+      val res = result.deltas.map(_._1)
+    }
+  }
+
   "BigDiffy avroKeyFn" should "work with nullable key" in {
     val record = specificRecordOf[TestRecord].sample.get
     record.getNullableFields.setIntField(null)


### PR DESCRIPTION
https://github.com/spotify/ratatool/pull/160 allowed for null values in keys.  This adds a warning whenever we encounter a null key.  Also throw an error whenever keys are non-unique as that might be somewhat easier to do by accident for nullable fields now