### PR TITLE
add check that GCS output begins with gs://

### DIFF
--- a/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/BigDiffy.scala
+++ b/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/BigDiffy.scala
@@ -482,6 +482,7 @@ object BigDiffy extends Command {
   def main(cmdlineArgs: Array[String]): Unit = run(cmdlineArgs)
 
   /** Scio pipeline for BigDiffy. */
+  //scalastyle:off cyclomatic.complexity
   def run(cmdlineArgs: Array[String]): Unit = {
     val (sc, args) = ContextAndArgs(cmdlineArgs)
 
@@ -504,6 +505,13 @@ object BigDiffy extends Command {
       case m => throw new IllegalArgumentException(s"output mode $m not supported")
     }
 
+    if (om == GCS && !output.startsWith("gs://")) {
+      // if combo of inputs is invalid, error out early
+      throw new IllegalArgumentException(s"Output mode is GCS, " +
+        s"but output $output is not a valid GCS location")
+    }
+
+    // validity checks passed, ok to run the diff
     val result = inputMode match {
       case "avro" =>
         val schema = new AvroSampler(rhs, conf = Some(sc.options))
@@ -525,5 +533,6 @@ object BigDiffy extends Command {
 
     sc.close().waitUntilDone()
   }
+  //scalastyle:on cyclomatic.complexity
 
 }

--- a/ratatool-diffy/src/test/scala/com/spotify/ratatool/diffy/BigDiffyTest.scala
+++ b/ratatool-diffy/src/test/scala/com/spotify/ratatool/diffy/BigDiffyTest.scala
@@ -186,4 +186,18 @@ class BigDiffyTest extends PipelineSpec {
 
     keyValues.toString shouldBe "foo_bar"
   }
+
+  it should "throw an exception when in GCS output mode and output is not gs://" in {
+    val exc = the[Exception] thrownBy {
+      val args = Array(
+        "--runner=DataflowRunner", "--project=fake", "--tempLocation=gs://tmp/tmp", // dataflow args
+        "--input-mode=avro", "--key=tmp", "--lhs=gs://tmp/lhs", "--rhs=gs://tmp/rhs",
+        "--output=abc" // no gs:// prefix
+        // if no output-mode. defaults to GCS
+         )
+      BigDiffy.run(args)
+    }
+
+    exc.getMessage shouldBe "Output mode is GCS, but output abc is not a valid GCS location"
+  }
 }


### PR DESCRIPTION
We received a user report that Ratatool succeeded in running a diff but they didn't know where the result was output to. We should fail fast if the output location is invalid. 