### PR TITLE
Add namespace to TestRecord enum & fixed (fix compile in circleci?)

### DIFF
--- a/ratatool-common/src/main/avro/TestRecord.avsc
+++ b/ratatool-common/src/main/avro/TestRecord.avsc
@@ -40,8 +40,12 @@
                     {"name": "double_field", "type": "double"},
                     {"name": "boolean_field", "type": "boolean"},
                     {"name": "string_field", "type": "string"},
-                    {"name": "fixed_field", "type": {"type": "fixed", "size": 16, "name": "UUID"}},
-                    {"name": "enum_field", "type": {"type": "enum", "name": "ABTest", "symbols": ["A", "B"]}},
+                    {"name": "fixed_field", "type": {"type": "fixed",
+                      "namespace": "com.spotify.ratatool.avro.specific",
+                      "size": 16, "name": "UUID"}},
+                    {"name": "enum_field", "type": {"type": "enum",
+                      "namespace": "com.spotify.ratatool.avro.specific",
+                      "name": "ABTest", "symbols": ["A", "B"]}},
                     {"name": "map_field", "type": {"type": "map", "values": "int"}},
                     {"name": "bytes_field", "type": "bytes" }
                 ]


### PR DESCRIPTION
Sometimes these are generated without a namespace
Then, we fail to compile because of this Scala bug: https://github.com/scala/bug/issues/4071?orig=1
We can make sure it gets generated with a namespace by specifying namespace
this is valid avro per https://avro.apache.org/docs/current/spec.html#Enums