### PR TITLE
Fixes bigDiffy param reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Or execute BigDiffy directly
 
 ```bash
 bin/ratatool bigDiffy \
-    --input_mode=avro \
+    --input-mode=avro \
     --key=record.key \
     --lhs=gs://path/to/left \
     --rhs=gs://path/to/right \


### PR DESCRIPTION
`input_mode` to `input-mode`

Error messaging should be improved for specific unknown params