### PR TITLE
Stringify byte buffers in diffy avro keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,19 @@ bin/ratatool bigDiffy \
     --runner=DataflowRunner ....
 ```
 
+
+
+# Development
+## Testing local changes to the CLI before releasing
+
+To test local changes before release:
+```
+$ sbt
+> project ratatoolCli
+> packArchive
+```
+and then find the built CLI at `ratatool-cli/target/ratatool-cli-{version}.tar.gz`
+
 # License
 
 Copyright 2016-2018 Spotify AB.

--- a/ratatool-common/src/test/resources/SimpleByteFieldRecord.avsc
+++ b/ratatool-common/src/test/resources/SimpleByteFieldRecord.avsc
@@ -1,0 +1,32 @@
+{
+  "type": "record",
+  "name": "SimpleByteFieldRecord",
+  "namespace": "com.spotify.ratatool.avro.generic",
+  "doc": "Record for testing",
+  "fields": [
+    {
+      "name": "nullable_fields",
+      "type": {
+        "type": "record",
+        "name": "SimpleNullableByteNestedRecord",
+        "namespace": "com.spotify.ratatool.avro.generic",
+        "doc": "Record for testing",
+        "fields": [
+          {"name": "byte_field", "type": ["null", "bytes"], "default": null}
+        ]
+      }
+    },
+    {
+      "name": "required_fields",
+      "type": {
+        "type": "record",
+        "name": "SimpleRequiredByteNestedRecord",
+        "namespace": "com.spotify.ratatool.avro.generic",
+        "doc": "Record for testing",
+        "fields": [
+          {"name": "byte_field", "type": "bytes"}
+        ]
+      }
+    }
+  ]
+}

--- a/ratatool-common/src/test/scala/com/spotify/ratatool/Schemas.scala
+++ b/ratatool-common/src/test/scala/com/spotify/ratatool/Schemas.scala
@@ -32,6 +32,9 @@ object Schemas {
   val evolvedSimpleAvroSchema: Schema =
     new Schema.Parser().parse(this.getClass.getResourceAsStream("/EvolvedSimpleRecord.avsc"))
 
+  val simpleAvroByteFieldSchema: Schema =
+    new Schema.Parser().parse(this.getClass.getResourceAsStream("/SimpleByteFieldRecord.avsc"))
+
   val tableSchema: TableSchema = new JsonObjectParser(new JacksonFactory)
     .parseAndClose(
       this.getClass.getResourceAsStream("/schema.json"),

--- a/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/BigDiffy.scala
+++ b/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/BigDiffy.scala
@@ -21,6 +21,7 @@ import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 
 import com.google.api.services.bigquery.model.{TableFieldSchema, TableRow, TableSchema}
+import com.google.common.io.BaseEncoding
 import com.google.protobuf.AbstractMessage
 import com.spotify.ratatool.Command
 import com.spotify.ratatool.samplers.AvroSampler
@@ -456,8 +457,8 @@ object BigDiffy extends Command with Serializable {
         }
         // handle bytes keys custom, so we get bytebuffer actual content and not toString metadata
         if (valueOfKey.isInstanceOf[ByteBuffer]) {
-          // might not necessarily be a utf8 string, but better to stringify the content somehow
-          new String(valueOfKey.asInstanceOf[ByteBuffer].array(), StandardCharsets.UTF_8.name())
+          // encode to hex string
+          BaseEncoding.base16().encode(valueOfKey.asInstanceOf[ByteBuffer].array())
         } else {
           String.valueOf(valueOfKey)
         }

--- a/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/BigDiffy.scala
+++ b/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/BigDiffy.scala
@@ -18,7 +18,6 @@
 package com.spotify.ratatool.diffy
 
 import java.nio.ByteBuffer
-import java.nio.charset.StandardCharsets
 
 import com.google.api.services.bigquery.model.{TableFieldSchema, TableRow, TableSchema}
 import com.google.common.io.BaseEncoding

--- a/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/BigDiffy.scala
+++ b/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/BigDiffy.scala
@@ -17,6 +17,9 @@
 
 package com.spotify.ratatool.diffy
 
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+
 import com.google.api.services.bigquery.model.{TableFieldSchema, TableRow, TableSchema}
 import com.google.protobuf.AbstractMessage
 import com.spotify.ratatool.Command
@@ -451,7 +454,13 @@ object BigDiffy extends Command with Serializable {
             s"""Null value found for key: ${xs.mkString(".")}.
                | If this is not expected check your data or use a different key.""".stripMargin)
         }
-        String.valueOf(valueOfKey)
+        // handle bytes keys custom, so we get bytebuffer actual content and not toString metadata
+        if (valueOfKey.isInstanceOf[ByteBuffer]) {
+          // might not necessarily be a utf8 string, but better to stringify the content somehow
+          new String(valueOfKey.asInstanceOf[ByteBuffer].array(), StandardCharsets.UTF_8.name())
+        } else {
+          String.valueOf(valueOfKey)
+        }
       } else {
         get(xs, i + 1, r.get(xs(i)).asInstanceOf[GenericRecord])
       }

--- a/ratatool-diffy/src/test/scala/com/spotify/ratatool/diffy/AvroDiffyTest.scala
+++ b/ratatool-diffy/src/test/scala/com/spotify/ratatool/diffy/AvroDiffyTest.scala
@@ -19,6 +19,7 @@ package com.spotify.ratatool.diffy
 
 import java.nio.ByteBuffer
 
+import com.google.common.io.BaseEncoding
 import com.spotify.ratatool.Schemas
 import com.spotify.ratatool.avro.specific._
 import com.spotify.ratatool.scalacheck._
@@ -231,6 +232,8 @@ class AvroDiffyTest extends AnyFlatSpec with Matchers {
 
   it should "support bytes keys in avroKeyFn" in {
     val ba = "testing".toCharArray.map(_.toByte)
+    val hex = BaseEncoding.base16().encode(ba)
+
 
     val bytes = ByteBuffer.wrap(ba)
     val x = new GenericRecordBuilder(Schemas.simpleAvroByteFieldSchema)
@@ -250,6 +253,6 @@ class AvroDiffyTest extends AnyFlatSpec with Matchers {
       ).build()
 
 
-    BigDiffy.avroKeyFn(Seq("nullable_fields.byte_field"))(x) should equal(MultiKey("testing"))
+    BigDiffy.avroKeyFn(Seq("nullable_fields.byte_field"))(x) should equal(MultiKey(hex))
   }
 }

--- a/ratatool-diffy/src/test/scala/com/spotify/ratatool/diffy/AvroDiffyTest.scala
+++ b/ratatool-diffy/src/test/scala/com/spotify/ratatool/diffy/AvroDiffyTest.scala
@@ -17,6 +17,8 @@
 
 package com.spotify.ratatool.diffy
 
+import java.nio.ByteBuffer
+
 import com.spotify.ratatool.Schemas
 import com.spotify.ratatool.avro.specific._
 import com.spotify.ratatool.scalacheck._
@@ -225,5 +227,29 @@ class AvroDiffyTest extends AnyFlatSpec with Matchers {
         UnknownDelta
       )
     ))
+  }
+
+  it should "support bytes keys in avroKeyFn" in {
+    val ba = "testing".toCharArray.map(_.toByte)
+
+    val bytes = ByteBuffer.wrap(ba)
+    val x = new GenericRecordBuilder(Schemas.simpleAvroByteFieldSchema)
+      .set(
+        "nullable_fields",
+        new GenericRecordBuilder(Schemas.simpleAvroByteFieldSchema.getField("nullable_fields")
+          .schema())
+          .set("byte_field", bytes)
+          .build()
+      )
+      .set(
+        "required_fields",
+        new GenericRecordBuilder(Schemas.simpleAvroByteFieldSchema.getField("required_fields")
+          .schema())
+          .set("byte_field", bytes)
+          .build()
+      ).build()
+
+
+    BigDiffy.avroKeyFn(Seq("nullable_fields.byte_field"))(x) should equal(MultiKey("testing"))
   }
 }


### PR DESCRIPTION
The default toString for a byte buffer doesn't contain its content,
 just metadata that's the same for every byte buffer of the same size.
If you used a bytes field in Avro as your key,
this would cause a hot key of that default string, rather than grouping by key values.

This fix uses the hex version of what's actually inside the buffer.

confirmed with user that diff job succeeds with this change in place