### PR TITLE
fix broken compile on master, & upgrade lib

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ val algebirdVersion = "0.13.7"
 val avroVersion = "1.8.2"
 val beamVersion = "2.22.0"
 val bigqueryVersion = "v2-rev20190917-1.30.3"
-val gcsVersion = "hadoop2-2.0.0"
+val gcsVersion = "2.1.3"
 val guavaVersion = "28.2-jre" // make sure this stays compatible with scio + beam
 val hadoopVersion = "2.7.7"
 val jodaTimeVersion = "2.10.6"
@@ -225,7 +225,8 @@ lazy val ratatoolExtras = project
       "org.apache.parquet" % "parquet-avro" % parquetVersion,
       "org.apache.avro" % "avro" % avroVersion,
       "org.apache.hadoop" % "hadoop-client" % hadoopVersion exclude ("org.slf4j", "slf4j-log4j12"),
-      "com.google.cloud.bigdataoss" % "gcs-connector" % gcsVersion,
+      "com.google.cloud.bigdataoss" % "gcs-connector" % s"hadoop2-$gcsVersion",
+      "com.google.cloud.bigdataoss" % "util" % gcsVersion,
       "org.scalatest" %% "scalatest" % scalaTestVersion % "test"
 ),
     testOptions in Test += Tests.Argument(TestFrameworks.ScalaCheck, "-verbosity", "3")


### PR DESCRIPTION
fixes: currently unable to release as extras fails to compile locally, maybe this used to be pulled in transitively?

```
[error] /home/anned/spotify-git/ratatool/ratatool-extras/src/main/java/com/spotify/ratatool/GcsConfiguration.java:87:1: cannot access com.google.cloud.hadoop.util.EntriesCredentialConfiguration
[error]   class file for com.google.cloud.hadoop.util.EntriesCredentialConfiguration not found
[error] HadoopCredentialConfiguration.BASE_KEY_PREFIX
[error] /home/anned/spotify-git/ratatool/ratatool-extras/src/main/java/com/spotify/ratatool/GcsConfiguration.java:88:1: cannot find symbol
[error]   symbol:   variable ENABLE_SERVICE_ACCOUNTS_SUFFIX
[error]   location: class com.google.cloud.hadoop.util.HadoopCredentialConfiguration
[error] HadoopCredentialConfiguration.ENABLE_SERVICE_ACCOUNTS_SUFFIX
[error] /home/anned/spotify-git/ratatool/ratatool-extras/src/main/java/com/spotify/ratatool/GcsConfiguration.java:91:1: cannot find symbol
[error]   symbol:   variable BASE_KEY_PREFIX
[error]   location: class com.google.cloud.hadoop.util.HadoopCredentialConfiguration
[error] HadoopCredentialConfiguration.BASE_KEY_PREFIX
[error] /home/anned/spotify-git/ratatool/ratatool-extras/src/main/java/com/spotify/ratatool/GcsConfiguration.java:92:1: cannot find symbol
[error]   symbol:   variable CLIENT_ID_SUFFIX
[error]   location: class com.google.cloud.hadoop.util.HadoopCredentialConfiguration
[error] HadoopCredentialConfiguration.CLIENT_ID_SUFFIX
[error] /home/anned/spotify-git/ratatool/ratatool-extras/src/main/java/com/spotify/ratatool/GcsConfiguration.java:95:1: cannot find symbol
[error]   symbol:   variable BASE_KEY_PREFIX
[error]   location: class com.google.cloud.hadoop.util.HadoopCredentialConfiguration
[error] HadoopCredentialConfiguration.BASE_KEY_PREFIX
[error] /home/anned/spotify-git/ratatool/ratatool-extras/src/main/java/com/spotify/ratatool/GcsConfiguration.java:96:1: cannot find symbol
[error]   symbol:   variable CLIENT_SECRET_SUFFIX
[error]   location: class com.google.cloud.hadoop.util.HadoopCredentialConfiguration
[error] HadoopCredentialConfiguration.CLIENT_SECRET_SUFFIX
[error] (ratatoolExtras / Compile / compileIncremental
```