### PR TITLE
Update documentation: Case class generators has moved to magnolify

### DIFF
--- a/ratatool-scalacheck/README.md
+++ b/ratatool-scalacheck/README.md
@@ -41,3 +41,33 @@ Implicit Arbitrary instances are also available for Avro and Protobuf records. E
 val avroArb: Arbitrary[MyRecord] = implicitly[Arbitrary[MyRecord]]
 
 ```
+
+## CaseClassGenerator (no longer supported since v0.3.14) 
+
+Given a case class containing fields, and (potentially non-arbitrary) generators for individual 
+fields in the implicit scope, generates a Gen for the case class. 
+
+Inspired by and code based on what 
+[Scalacheck-Magnolia](https://github.com/mrdziuban/scalacheck-magnolia) does for Arbitrary. 
+
+
+Note that this works with Scio 0.7.x and earlier, due to [this Magnolia change](https://github.com/propensive/magnolia/pull/152) added to Scio [here](https://github.com/spotify/scio/pull/2241/).
+You may see a `java.lang.NoSuchMethodError: magnolia.TypeName.<init>` if you're using an 
+incompatible Scio version. 
+
+```scala
+import com.spotify.ratatool.scalacheck.CaseClassGenerator._
+import org.scalacheck.Gen
+
+case class Sample(opt: Option[String])
+
+object OptionGen {
+  implicit def optionAlwaysSome[T](implicit genT: Gen[T]): Gen[Option[T]] = genT.map(Some(_))
+}
+
+object ValidCaseClassGen {
+  import OptionGen.optionAlwaysSome
+  implicit def string: Gen[String] = Gen.alphaNumStr
+  def sampleGen: Gen[Sample] = deriveGen[Sample] // always gens a Sample(Some(alphaNumString))
+}
+```

--- a/ratatool-scalacheck/README.md
+++ b/ratatool-scalacheck/README.md
@@ -41,32 +41,3 @@ Implicit Arbitrary instances are also available for Avro and Protobuf records. E
 val avroArb: Arbitrary[MyRecord] = implicitly[Arbitrary[MyRecord]]
 
 ```
-## CaseClassGenerator
-
-Given a case class containing fields, and (potentially non-arbitrary) generators for individual 
-fields in the implicit scope, generates a Gen for the case class. 
-
-Inspired by and code based on what 
-[Scalacheck-Magnolia](https://github.com/mrdziuban/scalacheck-magnolia) does for Arbitrary. 
-
-
-Note that this works with Scio 0.7.x and earlier, due to [this Magnolia change](https://github.com/propensive/magnolia/pull/152) added to Scio [here](https://github.com/spotify/scio/pull/2241/).
-You may see a `java.lang.NoSuchMethodError: magnolia.TypeName.<init>` if you're using an 
-incompatible Scio version. 
-
-```scala
-import com.spotify.ratatool.scalacheck.CaseClassGenerator._
-import org.scalacheck.Gen
-
-case class Sample(opt: Option[String])
-
-object OptionGen {
-  implicit def optionAlwaysSome[T](implicit genT: Gen[T]): Gen[Option[T]] = genT.map(Some(_))
-}
-
-object ValidCaseClassGen {
-  import OptionGen.optionAlwaysSome
-  implicit def string: Gen[String] = Gen.alphaNumStr
-  def sampleGen: Gen[Sample] = deriveGen[Sample] // always gens a Sample(Some(alphaNumString))
-}
-```

--- a/ratatool-scalacheck/README.md
+++ b/ratatool-scalacheck/README.md
@@ -42,7 +42,7 @@ val avroArb: Arbitrary[MyRecord] = implicitly[Arbitrary[MyRecord]]
 
 ```
 
-## CaseClassGenerator (no longer supported since v0.3.14) 
+## CaseClassGenerator (no longer supported since [v0.3.14](https://github.com/spotify/ratatool/releases/tag/v0.3.14)) 
 
 Given a case class containing fields, and (potentially non-arbitrary) generators for individual 
 fields in the implicit scope, generates a Gen for the case class. 

--- a/ratatool-scalacheck/README.md
+++ b/ratatool-scalacheck/README.md
@@ -42,7 +42,10 @@ val avroArb: Arbitrary[MyRecord] = implicitly[Arbitrary[MyRecord]]
 
 ```
 
-## CaseClassGenerator (no longer supported since [v0.3.14](https://github.com/spotify/ratatool/releases/tag/v0.3.14)) 
+## CaseClassGenerator 
+
+Removed since [v0.3.14](https://github.com/spotify/ratatool/releases/tag/v0.3.14)
+> CaseClassGenerator has been removed. If this is needed users should migrate to generators in [magnolify](https://github.com/spotify/magnolify)
 
 Given a case class containing fields, and (potentially non-arbitrary) generators for individual 
 fields in the implicit scope, generates a Gen for the case class. 


### PR DESCRIPTION
Since [v0.3.1.4](https://github.com/spotify/ratatool/releases/tag/v0.3.14), CaseClassGenerator is no longer in this repository

> CaseClassGenerator has been removed. If this is needed users should migrate to generators in magnolify

Remove related documentation