### PR TITLE
Fix some warnings and add command line parsing for unordered field keys

### DIFF
--- a/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/BigDiffy.scala
+++ b/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/BigDiffy.scala
@@ -431,8 +431,8 @@ object BigDiffy extends Command with Serializable {
         |  --output=<output>                File path prefix for output
         |  --ignore=<keys>                  ',' separated field list to ignore
         |  --unordered=<keys>               ',' separated field list to treat as unordered
-        |  --unorderedFieldKey=<key>        ',' separated list of keys for fields which are unordered nested records. Mappings use '->'
-        |                                   For example --unorderedFieldKey=fieldPath->fieldKey,otherPath->otherKey
+        |  --unorderedFieldKey=<key>        ',' separated list of keys for fields which are unordered nested records. Mappings use ':'
+        |                                   For example --unorderedFieldKey=fieldPath:fieldKey,otherPath:otherKey
         |  [--with-header]                  Output all TSVs with header rows. Defaults to false
         |  [--ignore-nan]                   Ignore NaN values when computing stats for differences
         |
@@ -495,7 +495,7 @@ object BigDiffy extends Command with Serializable {
 
   private[diffy] def unorderedKeysMap(unorderedKeysArgs: List[String]): Try[Map[String, String]] = {
     Try(unorderedKeysArgs.map { arg =>
-      val keyMappings = arg.split("->")
+      val keyMappings = arg.split(":")
       assert(keyMappings.size == 2, s"Invalid unordered field key mapping $arg")
       (keyMappings(0), keyMappings(1))
     }.toMap)

--- a/ratatool-diffy/src/test/scala/com/spotify/ratatool/diffy/BigDiffyTest.scala
+++ b/ratatool-diffy/src/test/scala/com/spotify/ratatool/diffy/BigDiffyTest.scala
@@ -29,6 +29,8 @@ import com.spotify.scio.testing.PipelineSpec
 
 import com.google.api.services.bigquery.model.TableRow
 
+import scala.language.higherKinds
+
 class BigDiffyTest extends PipelineSpec {
 
   val keys = (1 to 1000).map(k => MultiKey("key" + k))
@@ -238,6 +240,15 @@ class BigDiffyTest extends PipelineSpec {
     val keyValues = BigDiffy.tableRowKeyFn(keys)(record.asInstanceOf[TableRow])
 
     keyValues.toString shouldBe "foo_bar"
+  }
+
+  "BigDiffy unorderedKeysMap" should "work with multiple unordered keys" in {
+    val keyMappings = List("record.nested_record->key", "record.other_nested_record->other_key")
+    val unorderdKeys = BigDiffy.unorderedKeysMap(keyMappings)
+
+    unorderdKeys.isSuccess shouldBe true
+    unorderdKeys.get shouldBe Map("record.nested_record" -> "key",
+      "record.other_nested_record" -> "other_key")
   }
 
   it should "throw an exception when in GCS output mode and output is not gs://" in {

--- a/ratatool-diffy/src/test/scala/com/spotify/ratatool/diffy/BigDiffyTest.scala
+++ b/ratatool-diffy/src/test/scala/com/spotify/ratatool/diffy/BigDiffyTest.scala
@@ -243,11 +243,11 @@ class BigDiffyTest extends PipelineSpec {
   }
 
   "BigDiffy unorderedKeysMap" should "work with multiple unordered keys" in {
-    val keyMappings = List("record.nested_record->key", "record.other_nested_record->other_key")
-    val unorderdKeys = BigDiffy.unorderedKeysMap(keyMappings)
+    val keyMappings = List("record.nested_record:key", "record.other_nested_record:other_key")
+    val unorderedKeys = BigDiffy.unorderedKeysMap(keyMappings)
 
-    unorderdKeys.isSuccess shouldBe true
-    unorderdKeys.get shouldBe Map("record.nested_record" -> "key",
+    unorderedKeys.isSuccess shouldBe true
+    unorderedKeys.get shouldBe Map("record.nested_record" -> "key",
       "record.other_nested_record" -> "other_key")
   }
 

--- a/ratatool-sampling/src/main/scala/com/spotify/ratatool/samplers/BigSampler.scala
+++ b/ratatool-sampling/src/main/scala/com/spotify/ratatool/samplers/BigSampler.scala
@@ -38,7 +38,7 @@ import org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers
 import org.apache.beam.sdk.options.PipelineOptions
 import org.slf4j.LoggerFactory
 
-import scala.language.existentials
+import scala.language.{existentials, higherKinds}
 import scala.util.Try
 import scala.reflect.ClassTag
 

--- a/ratatool-sampling/src/main/scala/com/spotify/ratatool/samplers/util/SamplerSCollectionFunctions.scala
+++ b/ratatool-sampling/src/main/scala/com/spotify/ratatool/samplers/util/SamplerSCollectionFunctions.scala
@@ -23,6 +23,7 @@ import com.spotify.scio.coders.Coder
 import org.apache.beam.sdk.transforms.ParDo
 import org.slf4j.{Logger, LoggerFactory}
 
+import scala.language.higherKinds
 import scala.reflect.ClassTag
 import scala.math._
 

--- a/ratatool-scalacheck/src/test/scala/com/spotify/ratatool/scalacheck/ProtoBufGeneratorTest.scala
+++ b/ratatool-scalacheck/src/test/scala/com/spotify/ratatool/scalacheck/ProtoBufGeneratorTest.scala
@@ -19,7 +19,7 @@ package com.spotify.ratatool.scalacheck
 
 import com.spotify.ratatool.proto.Schemas.{OptionalNestedRecord, RequiredNestedRecord, TestRecord}
 import org.scalacheck.{Gen, Properties}
-import org.scalacheck.Prop.{BooleanOperators, all, forAll}
+import org.scalacheck.Prop.{propBoolean, all, forAll}
 
 
 object ProtoBufGeneratorTest extends Properties("ProtoBufGenerator") {


### PR DESCRIPTION
Don't know if this is a good idea or not but it was annoying to me to have to import ratatool as a dependency just to use this feature (and therefore commit diff jobs into a pipeline repo). Basically allows `->` demarcated field key mappings for nested records that can be ',' delimited to specify multiple field mappings. Let me know what you think