### PR TITLE
[WIP] clarify limits of schema evolution

### DIFF
--- a/ratatool-diffy/README.md
+++ b/ratatool-diffy/README.md
@@ -65,8 +65,9 @@ If you need to use `unorderedFieldKeys` to diff nested repeated records, then yo
  as this is currently unsupported from the CLI.
 
 ## Schema Evolution
-If you are trying to diff two schemas that are backwards compatible, you should put the "new" schema
- which is backwards compatible on the RHS. You can also add the new fields to the ignore list to
- prune them from the diff results. For BigQuery, the diff is applied across the union of the two
- schemas. For Avro, the RHS is used as the source of truth, and the diff is assumed to apply to all
- fields in the RHS unless it is specified in `ignore`.
+
+If you are diffing two avro datasets, their schemas must be backwards compatible (with the "new" schema on the RHS).
+
+For BigQuery datasets, the diff is applied across the union of the two schemas.
+
+You can also add the new fields to the ignore list to prune them from the diff results.


### PR DESCRIPTION
a user ran into an avro error diffing two schemas where the rhs one added a non-nullable field. waiting on her to confirm that a backwards-compatible schema works.
this is based on my understanding of the current behavior after reading [AvroDiffy](https://github.com/spotify/ratatool/blob/master/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/AvroDiffy.scala).
not sure yet if we want to change this behavior.