### PR TITLE
Add option to convert nulls for BQ keys

### DIFF
--- a/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/BigDiffy.scala
+++ b/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/BigDiffy.scala
@@ -484,7 +484,16 @@ object BigDiffy extends Command with Serializable {
     @tailrec
     def get(xs: Array[String], i: Int, r: java.util.Map[String, AnyRef]): String =
       if (i == xs.length - 1) {
-        r.get(xs(i)).toString
+        val valueOfKey = r.get(xs(i))
+        if (valueOfKey == null) {
+          logger.warn(
+            s"""Null value found for key: ${xs.mkString(".")}.
+               | If this is not expected check your data or use a different key.""".stripMargin)
+        }
+
+        // Implicitly converts nulls to "null"
+        // Same as for Avro string case above
+        String.valueOf(valueOfKey)
       } else {
         get(xs, i + 1, r.get(xs(i)).asInstanceOf[java.util.Map[String, AnyRef]])
       }


### PR DESCRIPTION
Adds the `convert-nulls` option to convert nulls to "null" for use as keys in BigQuery diffs. This is very useful for comparing output
datasets when `null` is an expected value/category for a string key e.g. in datasets where `null` country codes might be expected for example.

From the code it seems this is already the behaviour in Avro diffs, it is only BQ diffs that would fail previously.