### PR TITLE
Add GenTestUtils

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,7 @@ val scalaCollectionCompatVersion = "2.5.0"
 val scioVersion = "0.11.1"
 val scoptVersion = "4.0.1"
 val shapelessVersion = "2.3.7"
+val sourcecodeVersion = "0.2.7"
 val slf4jVersion = "1.7.32"
 
 def isScala213x: Def.Initialize[Boolean] = Def.setting {
@@ -297,7 +298,8 @@ lazy val ratatoolScalacheck = project
       "org.scalacheck" %% "scalacheck" % scalaCheckVersion,
       "com.google.apis" % "google-api-services-bigquery" % bigqueryVersion % "provided",
       "org.apache.beam" % "beam-sdks-java-core" % beamVersion,
-      "org.scalatest" %% "scalatest" % scalaTestVersion % "test"
+      "org.scalatest" %% "scalatest" % scalaTestVersion % "test",
+      "com.lihaoyi" %% "sourcecode" % sourcecodeVersion
     )
   )
   .enablePlugins(ProtobufPlugin)

--- a/ratatool-scalacheck/README.md
+++ b/ratatool-scalacheck/README.md
@@ -39,7 +39,9 @@ Implicit Arbitrary instances are also available for Avro and Protobuf records. E
 val avroArb: Arbitrary[MyRecord] = implicitly[Arbitrary[MyRecord]]
 ```
 
-Multiple `Gen` instances can be composed together with a for-comprehension. This will cause the data to be generated with the same seed.
+Multiple `Gen` instances can be composed together with a for-comprehension, which will cause the data to be generated with the same seed,
+which can aid in test reproducibility. See `withGen` below for a convenience function for capturing failing seeds.
+
 ```scala
 val genData: Gen[(MyRecord, Int)] = for {
  record <- avroGen
@@ -50,16 +52,9 @@ val genData: Gen[(MyRecord, Int)] = for {
 val data: Option[(MyRecord, Int)] = genData.sample
 ```
 
-Due to scalacheck internals generation can fail so the return type of `.sample` is `Option[A]`.
-In general, calling `.get` on an `Option` is an anti-pattern because this can produce `NoSuchElementException`.
-When used in conjunction with scalacheck, calling `.sample.get` can be the root cause of flaky tests.
-
-Repeatedly calling `.sample` is also an anti-pattern as each generated instance will be produced with a different random seed and tests will not be reproducible.
-Instead, use `withGen` as described below.
-
 ## In tests
 
-When using `Gen` to create data in a test, use `withGen` to capture the random seed and print it on failure:
+When using `Gen` to create data in a test, `withGen` can be used to capture the random seed and print it on failure:
 ```scala
 import com.spotify.ratatool.scalacheck.GenTestUtils
 

--- a/ratatool-scalacheck/README.md
+++ b/ratatool-scalacheck/README.md
@@ -9,9 +9,7 @@ Ratatool-Scalacheck contains classes and functions which help with using Scalach
 import com.spotify.ratatool.scalacheck._
 import org.scalacheck.Gen
 
-
 val avroGen: Gen[MyRecord] = avroOf[MyRecord]
-val record: MyRecord = avroGen.sample.get
 ```
 
 Ratatool also provides `protobufOf[T]` and `tableRowOf(schema)` defined [here](https://github.com/spotify/ratatool/tree/master/ratatool-scalacheck/src/main/scala/com/spotify/ratatool/scalacheck).
@@ -39,7 +37,50 @@ Implicit Arbitrary instances are also available for Avro and Protobuf records. E
 
 ```scala
 val avroArb: Arbitrary[MyRecord] = implicitly[Arbitrary[MyRecord]]
+```
 
+Multiple `Gen` instances can be composed together with a for-comprehension. This will cause the data to be generated with the same seed.
+```scala
+val genData: Gen[(MyRecord, Int)] = for {
+ record <- avroGen
+ i <- Gen.choose(0, 10)
+} yield (record, i)
+
+// .sample gets a random seed
+val data: Option[(MyRecord, Int)] = genData.sample
+```
+
+Due to scalacheck internals generation can fail so the return type of `.sample` is `Option[A]`.
+In general, calling `.get` on an `Option` is an anti-pattern because this can produce `NoSuchElementException`.
+When used in conjunction with scalacheck, calling `.sample.get` can be the root cause of flaky tests.
+
+Repeatedly calling `.sample` is also an anti-pattern as each generated instance will be produced with a different random seed and tests will not be reproducible.
+Instead, use `withGen` as described below.
+
+## In tests
+
+When using `Gen` to create data in a test, use `withGen` to capture the random seed and print it on failure:
+```scala
+import com.spotify.ratatool.scalacheck.GenTestUtils
+
+class MyTest extends GenTestUtils {
+  // ...
+  val inputGen: Gen[List[Int]] = Gen.listOfN(10, Gen.choose(1, 10))
+  withGen(inputGen) { input =>
+    throw new RuntimeException("woops")
+  }
+  // will log:
+  // Failure at MyTest:3. Seed: m82pUlOaHUcyWDadIbOIdEOR7GW4ebmN1oR0a0vbLpG=
+  
+  // ...
+}
+```
+
+To reproduce a test failure, a static seed can be passed as either a base-64 string or an `org.scalacheck.rng.Seed`:
+```scala
+withGen(inputGen, "m82pUlOaHUcyWDadIbOIdEOR7GW4ebmN1oR0a0vbLpG=") { input =>
+  // ...
+}
 ```
 
 ## CaseClassGenerator 

--- a/ratatool-scalacheck/src/main/scala/com/spotify/ratatool/scalacheck/GenTestUtils.scala
+++ b/ratatool-scalacheck/src/main/scala/com/spotify/ratatool/scalacheck/GenTestUtils.scala
@@ -62,7 +62,8 @@ trait GenTestUtils {
       case None =>
         logger.error(
           s"Failed to generate a valid value at ${name.value}:${line.value}. " +
-            s"Consider rewriting Gen instances to be less failure-prone. " +
+            s"This can occur when Gen instances are are not guaranteed to produce a value, " +
+            s"e.g. when candidate values are restricted with filter() or suchThat(). " +
             s"Seed: ${seed.toBase64}"
         )
         None

--- a/ratatool-scalacheck/src/main/scala/com/spotify/ratatool/scalacheck/GenTestUtils.scala
+++ b/ratatool-scalacheck/src/main/scala/com/spotify/ratatool/scalacheck/GenTestUtils.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2022 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.ratatool.scalacheck
+
+import org.scalacheck.Gen
+import org.scalacheck.rng.Seed
+import org.slf4j.LoggerFactory
+
+import scala.util.Try
+
+/** Trait with utility methods for unit testing pipelines. */
+trait GenTestUtils {
+  private[this] val logger = LoggerFactory.getLogger(this.getClass)
+
+  /**
+   * Generate an instance of `A` from `genA` using a random seed.
+   *
+   * @return
+   *   The result of `fn` applied to the generated `A`, or `None` on generation failure.
+   */
+  def withGen[A, T](genA: Gen[A])(
+    fn: A => T
+  )(implicit line: sourcecode.Line, name: sourcecode.FileName): Option[T] =
+    withGen(genA, Seed.random())(fn)(line, name)
+
+  /**
+   * Generate an instance of `A` from `genA` using a the seed specified by `base64Seed`.
+   *
+   * @return
+   *   The result of `fn` applied to the generated `A`, or `None` on generation failure.
+   */
+  def withGen[A, T](genA: Gen[A], base64Seed: String)(
+    fn: A => T
+  )(implicit line: sourcecode.Line, name: sourcecode.FileName): Option[T] =
+    withGen(genA, Seed.fromBase64(base64Seed).get)(fn)(line, name)
+
+  /**
+   * Generate an instance of `A` from `genA` using a the seed specified by `seed`.
+   *
+   * @return
+   *   The result of `fn` applied to the generated `A`, or `None` on generation failure.
+   */
+  def withGen[A, T](genA: Gen[A], seed: Seed)(
+    fn: A => T
+  )(implicit line: sourcecode.Line, name: sourcecode.FileName): Option[T] = {
+    genA.apply(Gen.Parameters.default, seed) match {
+      case None =>
+        logger.error(
+          s"Failed to generate a valid value at ${name.value}:${line.value}. " +
+            s"Consider rewriting Gen instances to be less failure-prone. " +
+            s"Seed: ${seed.toBase64}"
+        )
+        None
+      case Some(a) =>
+        val r = Try(fn(a)).map(Some(_))
+        if (r.isFailure)
+          logger.error(s"Failure at ${name.value}:${line.value}. Seed: ${seed.toBase64}")
+        r.get
+    }
+  }
+}

--- a/ratatool-scalacheck/src/test/scala/com/spotify/ratatool/scalacheck/GenTestUtilsTest.scala
+++ b/ratatool-scalacheck/src/test/scala/com/spotify/ratatool/scalacheck/GenTestUtilsTest.scala
@@ -1,0 +1,40 @@
+package com.spotify.ratatool.scalacheck
+
+import org.scalacheck.Gen
+import org.scalacheck.rng.Seed
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class GenTestUtilsTest extends AnyFlatSpec with Matchers with GenTestUtils {
+  "GenTestUtils.withGen" should "generate a test case and have an optional return value" in {
+    val x = withGen(Gen.const(1))(i => i)
+    assert(x.contains(1))
+  }
+
+  it should "return None on test case generation failure, not throw" in {
+    val x = withGen(Gen.const(1).suchThat(_ => false))(_ => ())
+    assert(x.isEmpty)
+  }
+
+  it should "propagate errors" in {
+    assertThrows[RuntimeException] {
+      withGen(Gen.const(1)) { _ =>
+        throw new RuntimeException("xxx")
+      }
+    }
+  }
+
+  it should "accept a static seed" in {
+    val seed = Seed.random()
+    val x = withGen(Gen.choose(1, 10), seed)(i => i)
+    val y = withGen(Gen.choose(1, 10), seed)(i => i)
+    assert(x == y)
+  }
+
+  it should "accept a base64 string seed" in {
+    val seed = Seed.random().toBase64
+    val x = withGen(Gen.choose(1, 10), seed)(i => i)
+    val y = withGen(Gen.choose(1, 10), seed)(i => i)
+    assert(x == y)
+  }
+}


### PR DESCRIPTION
Provides a standard way to log the seed on test failure and to handle generation failure.