### PR TITLE
add flogger backend dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -181,8 +181,7 @@ lazy val ratatoolSampling = project
       "com.twitter" %% "algebird-core" % algebirdVersion,
       "joda-time" % "joda-time" % jodaTimeVersion,
       "org.scalacheck" %% "scalacheck" % scalaCheckVersion,
-      "org.scalatest" %% "scalatest" % scalaTestVersion % "test",
-      "com.google.flogger" % "flogger-system-backend" % floggerVersion % "test"
+      "org.scalatest" %% "scalatest" % scalaTestVersion % "test"
     ),
     // In case of scalacheck failures print more info
     testOptions in Test += Tests.Argument(TestFrameworks.ScalaCheck, "-verbosity", "3"),
@@ -260,7 +259,8 @@ lazy val ratatoolExtras = project
       "org.apache.hadoop" % "hadoop-client" % hadoopVersion exclude ("org.slf4j", "slf4j-log4j12"),
       "com.google.cloud.bigdataoss" % "gcs-connector" % s"hadoop2-$gcsVersion",
       "com.google.cloud.bigdataoss" % "util" % gcsVersion,
-      "org.scalatest" %% "scalatest" % scalaTestVersion % "test"
+      "org.scalatest" %% "scalatest" % scalaTestVersion % "test",
+      "com.google.flogger" % "flogger-system-backend" % floggerVersion % "test"
     ),
     testOptions in Test += Tests.Argument(TestFrameworks.ScalaCheck, "-verbosity", "3")
   )

--- a/build.sbt
+++ b/build.sbt
@@ -36,6 +36,7 @@ val scoptVersion = "4.0.1"
 val shapelessVersion = "2.3.7"
 val sourcecodeVersion = "0.2.7"
 val slf4jVersion = "1.7.33"
+val floggerVersion = "0.7.4"
 
 def isScala213x: Def.Initialize[Boolean] = Def.setting {
   scalaBinaryVersion.value == "2.13"
@@ -180,7 +181,8 @@ lazy val ratatoolSampling = project
       "com.twitter" %% "algebird-core" % algebirdVersion,
       "joda-time" % "joda-time" % jodaTimeVersion,
       "org.scalacheck" %% "scalacheck" % scalaCheckVersion,
-      "org.scalatest" %% "scalatest" % scalaTestVersion % "test"
+      "org.scalatest" %% "scalatest" % scalaTestVersion % "test",
+      "com.google.flogger" % "flogger-system-backend" % floggerVersion % "test"
     ),
     // In case of scalacheck failures print more info
     testOptions in Test += Tests.Argument(TestFrameworks.ScalaCheck, "-verbosity", "3"),


### PR DESCRIPTION
I was getting a 

```
No logging platforms found in while using google flogger logging ClassNotFoundException: com.google.common.flogger.backend.system.DefaultPlatform
```

error when running the tests locally in ratatool. It looks like we need to add a logging backend to ratatool in order to have flogger function properly. According to the flogger docs, https://github.com/google/flogger#1-add-the-dependencies-on-flogger, we need to add https://mvnrepository.com/artifact/com.google.flogger/flogger-system-backend/0.7.4 to build.sbt.

I set the scope to `test` in order to avoid adding dependencies for our users binary.