### PR TITLE
Fix filepath wildcard for avro/parquet

### DIFF
--- a/ratatool-sampling/src/main/scala/com/spotify/ratatool/samplers/BigSampler.scala
+++ b/ratatool-sampling/src/main/scala/com/spotify/ratatool/samplers/BigSampler.scala
@@ -18,6 +18,7 @@ package com.spotify.ratatool.samplers
 
 import java.net.URI
 import java.nio.charset.Charset
+
 import com.google.api.services.bigquery.model.{TableFieldSchema, TableReference}
 import com.google.common.hash.{HashCode, Hasher, Hashing}
 import com.spotify.ratatool.samplers.util.SamplerSCollectionFunctions._

--- a/ratatool-sampling/src/main/scala/com/spotify/ratatool/samplers/BigSampler.scala
+++ b/ratatool-sampling/src/main/scala/com/spotify/ratatool/samplers/BigSampler.scala
@@ -33,7 +33,6 @@ import org.apache.avro.Schema
 import org.apache.avro.generic.GenericRecord
 import org.apache.beam.runners.dataflow.options.DataflowPipelineWorkerPoolOptions
 import org.apache.beam.sdk.io.FileSystems
-import org.apache.beam.sdk.io.fs.MatchResult.Metadata
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers
 import org.apache.beam.sdk.options.PipelineOptions
 import org.slf4j.LoggerFactory
@@ -156,10 +155,6 @@ object BigSampler extends Command {
     hasher: Hasher
   ): Hasher =
     BigSamplerAvro.hashAvroField(avroSchema)(r, f, hasher)
-
-  private[samplers] def parseFileExtension(fileMetadata: List[Metadata]) = {
-    fileMetadata
-  }
 
   // scalastyle:off method.length cyclomatic.complexity
   def singleInput(argv: Array[String]): ClosedTap[_] = {

--- a/ratatool-sampling/src/main/scala/com/spotify/ratatool/samplers/BigSampler.scala
+++ b/ratatool-sampling/src/main/scala/com/spotify/ratatool/samplers/BigSampler.scala
@@ -238,8 +238,6 @@ object BigSampler extends Command {
       val inputTbl = parseAsBigQueryTable(input).get
       val outputTbl = parseAsBigQueryTable(output).get
 
-      log.info("Running BigSamplerBigQuery sampler")
-
       BigSamplerBigQuery.sample(
         sc,
         inputTbl,
@@ -266,7 +264,7 @@ object BigSampler extends Command {
 
       input match {
         case avroPath if fileNames.exists(_.endsWith("avro")) =>
-          log.info("Running BigSamplerAvro sampler")
+          log.info(s"Found *.avro files in $avroPath, running BigSamplerAvro")
           BigSamplerAvro.sample(
             sc,
             avroPath,
@@ -282,7 +280,7 @@ object BigSampler extends Command {
             byteEncoding
           )
         case parquetPath if fileNames.exists(_.endsWith("parquet")) =>
-          log.info("Running BigSamplerParquet sampler")
+          log.info(s"Found *.parquet files in $parquetPath, running BigSamplerParquet")
           BigSamplerParquet.sample(
             sc,
             parquetPath,

--- a/ratatool-sampling/src/main/scala/com/spotify/ratatool/samplers/BigSampler.scala
+++ b/ratatool-sampling/src/main/scala/com/spotify/ratatool/samplers/BigSampler.scala
@@ -260,11 +260,11 @@ object BigSampler extends Command {
       FileSystems.setDefaultPipelineOptions(opts)
       val fileNames = FileSystems.`match`(input).metadata().asScala.map(_.resourceId().getFilename)
 
-      fileNames match {
+      input match {
         case avroPath if fileNames.exists(_.endsWith("avro")) =>
           BigSamplerAvro.sample(
             sc,
-            input,
+            avroPath,
             output,
             fields,
             samplePct,
@@ -279,7 +279,7 @@ object BigSampler extends Command {
         case parquetPath if fileNames.exists(_.endsWith("parquet")) =>
           BigSamplerParquet.sample(
             sc,
-            input,
+            parquetPath,
             output,
             fields,
             samplePct,

--- a/ratatool-sampling/src/test/scala/com/spotify/ratatool/samplers/BigSamplerTest.scala
+++ b/ratatool-sampling/src/test/scala/com/spotify/ratatool/samplers/BigSamplerTest.scala
@@ -461,7 +461,6 @@ sealed trait BigSamplerJobTestRoot
     ParquetIO.writeToFile(data1, schema, fileParquet1)
     ParquetIO.writeToFile(data2, schema, fileParquet2)
 
-
     dir.toFile.deleteOnExit()
     file1.deleteOnExit()
     file2.deleteOnExit()
@@ -523,7 +522,6 @@ class BigSamplerBasicJobTest extends BigSamplerJobTestRoot {
     countParquetRecords(s"$outDir/*.parquet").toDouble shouldBe totalElements
   }
 
-
   it should "work for 50% with hash field and seed" in withOutFile { outDir =>
     BigSampler.run(
       Array(
@@ -550,6 +548,26 @@ class BigSamplerBasicJobTest extends BigSamplerJobTestRoot {
     countParquetRecords(s"$outDir/*.parquet").toDouble shouldBe totalElements * 0.5 +- 2000
   }
 }
+
+class BigSamplerWildCardTest extends BigSamplerJobTestRoot {
+  override def data1Size: Int = 10000
+  override def data2Size: Int = 2500
+
+  override protected def beforeAll(configMap: ConfigMap): Unit = {
+    ParquetIO.writeToFile(data1, schema, fileParquet1)
+    ParquetIO.writeToFile(data2, schema, fileParquet2)
+
+    dir.toFile.deleteOnExit()
+    fileParquet1.deleteOnExit()
+    fileParquet2.deleteOnExit()
+  }
+
+  "BigSampler" should "work for wildcard without file extension" in withOutFile { outDir =>
+    BigSampler.run(Array(s"--input=$dir/part-*", s"--output=$outDir", "--sample=0.5"))
+    countParquetRecords(s"$outDir/*.parquet").toDouble shouldBe totalElements * 0.5 +- 250
+  }
+}
+
 
 class BigSamplerApproxDistJobTest extends BigSamplerJobTestRoot {
   override def data1Size: Int = 10000

--- a/ratatool-sampling/src/test/scala/com/spotify/ratatool/samplers/BigSamplerTest.scala
+++ b/ratatool-sampling/src/test/scala/com/spotify/ratatool/samplers/BigSamplerTest.scala
@@ -37,6 +37,7 @@ import scala.language.postfixOps
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
+// scalastyle:off file.size.limit
 object BigSamplerTest extends Properties("BigSampler") {
 
   private val testSeed = Some(42)

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -3,7 +3,7 @@
  <check level="error" class="org.scalastyle.file.FileTabChecker" enabled="true"></check>
  <check level="error" class="org.scalastyle.file.FileLengthChecker" enabled="true">
   <parameters>
-   <parameter name="maxFileLength"><![CDATA[800]]></parameter>
+   <parameter name="maxFileLength"><![CDATA[1000]]></parameter>
   </parameters>
  </check>
  <check level="error" class="org.scalastyle.file.HeaderMatchesChecker" enabled="true">

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -3,7 +3,7 @@
  <check level="error" class="org.scalastyle.file.FileTabChecker" enabled="true"></check>
  <check level="error" class="org.scalastyle.file.FileLengthChecker" enabled="true">
   <parameters>
-   <parameter name="maxFileLength"><![CDATA[1000]]></parameter>
+   <parameter name="maxFileLength"><![CDATA[800]]></parameter>
   </parameters>
  </check>
  <check level="error" class="org.scalastyle.file.HeaderMatchesChecker" enabled="true">


### PR DESCRIPTION
Below changes have been tested and confirmed to work. Also proposing alternative approach since I'm not a big fan of guessing whether we are dealing with Avro vs Parquet:

Approach (1)
- This PR, minimal change. Basically checking to see if the matching files has the relevant extensions and routing it to either `AvroSampler` or `ParquetSample`

Approach (2) 
- Not in this PR, but I think we should create a new arg called `mode` (which can be either `parquet`, `avro` or `bigquery`) and have that be a required field. It will be a breaking change, but then it will help avoid guessing which Sampler to use. 