### PR TITLE
Change yMap and add test

### DIFF
--- a/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/BigDiffy.scala
+++ b/ratatool-diffy/src/main/scala/com/spotify/ratatool/diffy/BigDiffy.scala
@@ -547,7 +547,7 @@ object BigDiffy extends Command with Serializable {
     y: Seq[TableFieldSchema]
   ): Seq[TableFieldSchema] = {
     val xMap = x.map(f => (f.getName, f)).toMap
-    val yMap = x.map(f => (f.getName, f)).toMap
+    val yMap = y.map(f => (f.getName, f)).toMap
     val names = mutable.LinkedHashSet.empty[String]
     xMap.foreach(kv => names.add(kv._1))
     yMap.foreach(kv => names.add(kv._1))


### PR DESCRIPTION
WHAT: Changing `mergeTableSchema` to support LHS as well as RHS schema, returning a schema containing all the fields of both schemas, and adding test for new functionality.

WHY: To make RHS schema be considered in `mergeTableSchema` when using bigdiffy in bigquery.

HOW: changes `val yMap = x.map(f => (f.getName, f)).toMap` to `val yMap = y.map(f => (f.getName, f)).toMap`

