### PR TITLE
Add logical decimal type support to avroOf

### DIFF
--- a/ratatool-common/src/main/avro/TestRecord.avsc
+++ b/ratatool-common/src/main/avro/TestRecord.avsc
@@ -47,7 +47,15 @@
                       "namespace": "com.spotify.ratatool.avro.specific",
                       "name": "ABTest", "symbols": ["A", "B"]}},
                     {"name": "map_field", "type": {"type": "map", "values": "int"}},
-                    {"name": "bytes_field", "type": "bytes" }
+                    {"name": "bytes_field", "type": "bytes" },
+                    {"name": "logical_decimal_field",
+                     "type": {
+                               "type": "bytes",
+                               "logicalType": "decimal",
+                               "precision": 32,
+                               "scale": 9
+                             }
+                     }
                 ]
             }
         },

--- a/ratatool-sampling/src/test/scala/com/spotify/ratatool/io/FixRandomData.scala
+++ b/ratatool-sampling/src/test/scala/com/spotify/ratatool/io/FixRandomData.scala
@@ -18,6 +18,8 @@
 package com.spotify.ratatool.io
 
 import com.spotify.ratatool.avro.specific.TestRecord
+import org.apache.avro.Conversions
+import org.apache.avro.specific.SpecificData
 
 import java.util.{HashMap => JHashMap, Map => JMap}
 import scala.jdk.CollectionConverters._
@@ -36,6 +38,9 @@ object FixRandomData {
       }
     }
 
+    // bug in avro 1.8.2. model's data is not initialized with conversions
+    // force decimal conversion on the default SpecificData instance
+    SpecificData.get().addLogicalTypeConversion(new Conversions.DecimalConversion())
     val newInstance = TestRecord.newBuilder(x).build()
 
     newInstance.getRequiredFields.setMapField(fixHashMap(x.getRequiredFields.getMapField))

--- a/ratatool-sampling/src/test/scala/com/spotify/ratatool/io/FixRandomData.scala
+++ b/ratatool-sampling/src/test/scala/com/spotify/ratatool/io/FixRandomData.scala
@@ -26,6 +26,10 @@ import scala.jdk.CollectionConverters._
 
 object FixRandomData {
 
+  // bug in avro 1.8.2. model's data is not initialized with conversions
+  // force decimal conversion on the default SpecificData instance
+  SpecificData.get().addLogicalTypeConversion(new Conversions.DecimalConversion())
+
   /** Fix equality for maps by converting Utf8 to String */
   def apply(x: TestRecord): TestRecord = {
     def fixHashMap[T](xs: JMap[CharSequence, T]): JMap[CharSequence, T] = {
@@ -38,9 +42,6 @@ object FixRandomData {
       }
     }
 
-    // bug in avro 1.8.2. model's data is not initialized with conversions
-    // force decimal conversion on the default SpecificData instance
-    SpecificData.get().addLogicalTypeConversion(new Conversions.DecimalConversion())
     val newInstance = TestRecord.newBuilder(x).build()
 
     newInstance.getRequiredFields.setMapField(fixHashMap(x.getRequiredFields.getMapField))

--- a/ratatool-scalacheck/src/test/scala/com/spotify/ratatool/scalacheck/AvroGeneratorTest.scala
+++ b/ratatool-scalacheck/src/test/scala/com/spotify/ratatool/scalacheck/AvroGeneratorTest.scala
@@ -42,6 +42,9 @@ object AvroGeneratorTest extends Properties("AvroGenerator") {
       _.getNullableFields.setStringField,
       m => s => m.getNullableFields.setUpperStringField(s.toUpperCase)
     )
+    .amend(Gen.const(BigDecimal("5.000000001").bigDecimal))(
+      _.getRequiredFields.setLogicalDecimalField
+    )
 
   val richTupGen = (specificRecordOf[TestRecord], specificRecordOf[TestRecord]).tupled
     .amend2(specificRecordOf[RequiredNestedRecord])(_.setRequiredFields, _.setRequiredFields)
@@ -58,7 +61,10 @@ object AvroGeneratorTest extends Properties("AvroGenerator") {
         r.getNullableFields.getDoubleField >= 10.0 && r.getNullableFields.getDoubleField <= 20.0,
       "Boolean" |: r.getNullableFields.getBooleanField == true,
       "String" |: r.getNullableFields.getStringField == "hello",
-      "String" |: r.getNullableFields.getUpperStringField == "HELLO"
+      "String" |: r.getNullableFields.getUpperStringField == "HELLO",
+      "BigDecimal" |: r.getRequiredFields.getLogicalDecimalField == BigDecimal(
+        "5.000000001"
+      ).bigDecimal
     )
   }
 


### PR DESCRIPTION
Attempt to add support for logical decimal types to avroOf See issue #178

It appears the Builder still fails when nested records rely on Avro Conversions since it only includes them in the generated classes for the nested record, and not for the parent record builder.

I also could not get it to work for nullable logical decimal types as the type coercion fails for the null array (it's a bit related to the above issue that we'd want it to call the Conversion and also handle nulls - e.g. 0 byte array -> null).

Note I also don't handle the case of a fixed underlying byte array size in the Avro schema, nor checking that the generated integer will fit inside the decimal's precision and scale - but at the moment the above issues are more blocking.