### PR TITLE
make bigsampler bq output partition configurable

### DIFF
--- a/ratatool-sampling/README.md
+++ b/ratatool-sampling/README.md
@@ -27,7 +27,7 @@ Usage: ratatool bigSampler [dataflow_options] [options]
   [--distribution=(uniform|stratified)]               An optional arg to sample for a stratified or uniform distribution. Must provide `distributionFields`
   [--distributionFields=<field1,field2,...>]          An optional list of fields to sample for distribution. Must provide `distribution`
   [--exact]                                           An optional arg for higher precision distribution sampling.
-  [--bigqueryPartitioning=<day|hour|month|year|null>] An optional arg specifying what partitioning to use for the output BigQuery table, or 'null' for no partitioning. Defaults to DAY.
+  [--bigqueryPartitioning=<day|hour|month|year|null>] An optional arg specifying what partitioning to use for the output BigQuery table, or 'null' for no partitioning. Defaults to day.
 
 Since this runs a Scio/Beam pipeline, Dataflow options will have to be provided. At a
 minimum, the following should be specified:

--- a/ratatool-sampling/README.md
+++ b/ratatool-sampling/README.md
@@ -18,16 +18,16 @@ For full details see [BigSample.scala](https://github.com/spotify/ratatool/blob/
 BigSampler - a tool for big data sampling
 Usage: ratatool bigSampler [dataflow_options] [options]
 
-  --sample=<percentage>                              Percentage of records to take in sample, a decimal between 0.0 and 1.0
-  --input=<path>                                     Input file path or BigQuery table
-  --output=<path>                                    Output file path or BigQuery table
-  [--fields=<field1,field2,...>]                     An optional list of fields to include in hashing for sampling cohort selection
-  [--seed=<seed>]                                    An optional seed used in hashing for sampling cohort selection
-  [--hashAlgorithm=(murmur|farm)]                    An optional arg to select the hashing algorithm for sampling cohort selection. Defaults to FarmHash for BigQuery compatibility
-  [--distribution=(uniform|stratified)]              An optional arg to sample for a stratified or uniform distribution. Must provide `distributionFields`
-  [--distributionFields=<field1,field2,...>]         An optional list of fields to sample for distribution. Must provide `distribution`
-  [--exact]                                          An optional arg for higher precision distribution sampling.
-  [--bigqueryPartitioning=<DAY|HOUR|MONTH|YEAR|null> An optional arg specifying what partitioning to use for the output BigQuery table, or 'null' for no partitioning. Defaults to DAY.
+  --sample=<percentage>                               Percentage of records to take in sample, a decimal between 0.0 and 1.0
+  --input=<path>                                      Input file path or BigQuery table
+  --output=<path>                                     Output file path or BigQuery table
+  [--fields=<field1,field2,...>]                      An optional list of fields to include in hashing for sampling cohort selection
+  [--seed=<seed>]                                     An optional seed used in hashing for sampling cohort selection
+  [--hashAlgorithm=(murmur|farm)]                     An optional arg to select the hashing algorithm for sampling cohort selection. Defaults to FarmHash for BigQuery compatibility
+  [--distribution=(uniform|stratified)]               An optional arg to sample for a stratified or uniform distribution. Must provide `distributionFields`
+  [--distributionFields=<field1,field2,...>]          An optional list of fields to sample for distribution. Must provide `distribution`
+  [--exact]                                           An optional arg for higher precision distribution sampling.
+  [--bigqueryPartitioning=<DAY|HOUR|MONTH|YEAR|null>] An optional arg specifying what partitioning to use for the output BigQuery table, or 'null' for no partitioning. Defaults to DAY.
 
 Since this runs a Scio/Beam pipeline, Dataflow options will have to be provided. At a
 minimum, the following should be specified:

--- a/ratatool-sampling/README.md
+++ b/ratatool-sampling/README.md
@@ -18,15 +18,16 @@ For full details see [BigSample.scala](https://github.com/spotify/ratatool/blob/
 BigSampler - a tool for big data sampling
 Usage: ratatool bigSampler [dataflow_options] [options]
 
-  --sample=<percentage>                      Percentage of records to take in sample, a decimal between 0.0 and 1.0
-  --input=<path>                             Input file path or BigQuery table
-  --output=<path>                            Output file path or BigQuery table
-  [--fields=<field1,field2,...>]             An optional list of fields to include in hashing for sampling cohort selection
-  [--seed=<seed>]                            An optional seed used in hashing for sampling cohort selection
-  [--hashAlgorithm=(murmur|farm)]            An optional arg to select the hashing algorithm for sampling cohort selection. Defaults to FarmHash for BigQuery compatibility
-  [--distribution=(uniform|stratified)]      An optional arg to sample for a stratified or uniform distribution. Must provide `distributionFields`
-  [--distributionFields=<field1,field2,...>] An optional list of fields to sample for distribution. Must provide `distribution`
-  [--exact]                                  An optional arg for higher precision distribution sampling.
+  --sample=<percentage>                              Percentage of records to take in sample, a decimal between 0.0 and 1.0
+  --input=<path>                                     Input file path or BigQuery table
+  --output=<path>                                    Output file path or BigQuery table
+  [--fields=<field1,field2,...>]                     An optional list of fields to include in hashing for sampling cohort selection
+  [--seed=<seed>]                                    An optional seed used in hashing for sampling cohort selection
+  [--hashAlgorithm=(murmur|farm)]                    An optional arg to select the hashing algorithm for sampling cohort selection. Defaults to FarmHash for BigQuery compatibility
+  [--distribution=(uniform|stratified)]              An optional arg to sample for a stratified or uniform distribution. Must provide `distributionFields`
+  [--distributionFields=<field1,field2,...>]         An optional list of fields to sample for distribution. Must provide `distribution`
+  [--exact]                                          An optional arg for higher precision distribution sampling.
+  [--bigqueryPartitioning=<DAY|HOUR|MONTH|YEAR|null> An optional arg specifying what partitioning to use for the output BigQuery table, or 'null' for no partitioning. Defaults to DAY.
 
 Since this runs a Scio/Beam pipeline, Dataflow options will have to be provided. At a
 minimum, the following should be specified:

--- a/ratatool-sampling/README.md
+++ b/ratatool-sampling/README.md
@@ -27,7 +27,7 @@ Usage: ratatool bigSampler [dataflow_options] [options]
   [--distribution=(uniform|stratified)]               An optional arg to sample for a stratified or uniform distribution. Must provide `distributionFields`
   [--distributionFields=<field1,field2,...>]          An optional list of fields to sample for distribution. Must provide `distribution`
   [--exact]                                           An optional arg for higher precision distribution sampling.
-  [--bigqueryPartitioning=<DAY|HOUR|MONTH|YEAR|null>] An optional arg specifying what partitioning to use for the output BigQuery table, or 'null' for no partitioning. Defaults to DAY.
+  [--bigqueryPartitioning=<day|hour|month|year|null>] An optional arg specifying what partitioning to use for the output BigQuery table, or 'null' for no partitioning. Defaults to DAY.
 
 Since this runs a Scio/Beam pipeline, Dataflow options will have to be provided. At a
 minimum, the following should be specified:

--- a/ratatool-sampling/src/main/scala/com/spotify/ratatool/samplers/BigSampler.scala
+++ b/ratatool-sampling/src/main/scala/com/spotify/ratatool/samplers/BigSampler.scala
@@ -101,16 +101,18 @@ object BigSampler extends Command {
     println(s"""BigSampler - a tool for big data sampling
         |Usage: ratatool $command [dataflow_options] [options]
         |
-        |  --sample=<percentage>                      Percentage of records to take in sample, a decimal between 0.0 and 1.0
-        |  --input=<path>                             Input file path or BigQuery table
-        |  --output=<path>                            Output file path or BigQuery table
-        |  [--fields=<field1,field2,...>]             An optional list of fields to include in hashing for sampling cohort selection
-        |  [--seed=<seed>]                            An optional seed used in hashing for sampling cohort selection
-        |  [--hashAlgorithm=(murmur|farm)]            An optional arg to select the hashing algorithm for sampling cohort selection. Defaults to FarmHash for BigQuery compatibility
-        |  [--distribution=(uniform|stratified)]      An optional arg to sample for a stratified or uniform distribution. Must provide `distributionFields`
-        |  [--distributionFields=<field1,field2,...>] An optional list of fields to sample for distribution. Must provide `distribution`
-        |  [--exact]                                  An optional arg for higher precision distribution sampling.
-        |  [--byteEncoding=(raw|hex|base64)]          An optional arg for how to encode fields of type bytes: raw bytes, hex encoded string, or base64 encoded string. Default is to hash raw bytes.
+        |  --sample=<percentage>                               Percentage of records to take in sample, a decimal between 0.0 and 1.0
+        |  --input=<path>                                      Input file path or BigQuery table
+        |  --output=<path>                                     Output file path or BigQuery table
+        |  [--fields=<field1,field2,...>]                      An optional list of fields to include in hashing for sampling cohort selection
+        |  [--seed=<seed>]                                     An optional seed used in hashing for sampling cohort selection
+        |  [--hashAlgorithm=(murmur|farm)]                     An optional arg to select the hashing algorithm for sampling cohort selection. Defaults to FarmHash for BigQuery compatibility
+        |  [--distribution=(uniform|stratified)]               An optional arg to sample for a stratified or uniform distribution. Must provide `distributionFields`
+        |  [--distributionFields=<field1,field2,...>]          An optional list of fields to sample for distribution. Must provide `distribution`
+        |  [--exact]                                           An optional arg for higher precision distribution sampling.
+        |  [--byteEncoding=(raw|hex|base64)]                   An optional arg for how to encode fields of type bytes: raw bytes, hex encoded string, or base64 encoded string. Default is to hash raw bytes.
+        |  [--bigqueryPartitioning=<day|hour|month|year|null>] An optional arg specifying what partitioning to use for the output BigQuery table, or 'null' for no partitioning. Defaults to DAY.
+        |
         |
         |Since this runs a Scio/Beam pipeline, Dataflow options will have to be provided. At a
         |minimum, the following should be specified:
@@ -191,7 +193,7 @@ object BigSampler extends Command {
           args.optional("distribution").map(SampleDistribution.fromString),
           args.list("distributionFields"),
           Precision.fromBoolean(args.boolean("exact", default = false)),
-          args.getOrElse("bigqueryPartitioning", "DAY")
+          args.getOrElse("bigqueryPartitioning", "day")
         )
       } catch {
         case e: Throwable =>
@@ -227,7 +229,7 @@ object BigSampler extends Command {
       )
       require(
         List("DAY", "HOUR", "MONTH", "YEAR", "NULL").contains(bigqueryPartitioning.toUpperCase),
-        s"bigqueryPartitioning must be either 'DAY', 'MONTH', 'YEAR', or 'NULL', found $bigqueryPartitioning"
+        s"bigqueryPartitioning must be either 'day', 'month', 'year', or 'null', found $bigqueryPartitioning"
       )
       val inputTbl = parseAsBigQueryTable(input).get
       val outputTbl = parseAsBigQueryTable(output).get

--- a/ratatool-sampling/src/main/scala/com/spotify/ratatool/samplers/BigSampler.scala
+++ b/ratatool-sampling/src/main/scala/com/spotify/ratatool/samplers/BigSampler.scala
@@ -175,7 +175,8 @@ object BigSampler extends Command {
       hashAlgorithm,
       distribution,
       distributionFields,
-      exact
+      exact,
+      bigqueryPartitioning
     ) =
       try {
         val pct = args("sample").toFloat
@@ -189,7 +190,8 @@ object BigSampler extends Command {
           args.optional("hashAlgorithm").map(HashAlgorithm.fromString).getOrElse(FarmHash),
           args.optional("distribution").map(SampleDistribution.fromString),
           args.list("distributionFields"),
-          Precision.fromBoolean(args.boolean("exact", default = false))
+          Precision.fromBoolean(args.boolean("exact", default = false)),
+          args.getOrElse("bigqueryPartitioning", "DAY")
         )
       } catch {
         case e: Throwable =>
@@ -223,6 +225,10 @@ object BigSampler extends Command {
         s"Input is a BigQuery table `$input`, output should be a BigQuery table too," +
           s"but instead it's `$output`."
       )
+      require(
+        List("DAY", "HOUR", "MONTH", "YEAR", "NULL").contains(bigqueryPartitioning.toUpperCase),
+        s"bigqueryPartitioning must be either 'DAY', 'MONTH', 'YEAR', or 'NULL', found $bigqueryPartitioning"
+      )
       val inputTbl = parseAsBigQueryTable(input).get
       val outputTbl = parseAsBigQueryTable(output).get
 
@@ -238,7 +244,8 @@ object BigSampler extends Command {
         distributionFields,
         exact,
         sizePerKey,
-        byteEncoding
+        byteEncoding,
+        bigqueryPartitioning.toUpperCase
       )
     } else if (parseAsURI(input).isDefined) {
       // right now only support for avro

--- a/ratatool-sampling/src/main/scala/com/spotify/ratatool/samplers/BigSampler.scala
+++ b/ratatool-sampling/src/main/scala/com/spotify/ratatool/samplers/BigSampler.scala
@@ -111,7 +111,7 @@ object BigSampler extends Command {
         |  [--distributionFields=<field1,field2,...>]          An optional list of fields to sample for distribution. Must provide `distribution`
         |  [--exact]                                           An optional arg for higher precision distribution sampling.
         |  [--byteEncoding=(raw|hex|base64)]                   An optional arg for how to encode fields of type bytes: raw bytes, hex encoded string, or base64 encoded string. Default is to hash raw bytes.
-        |  [--bigqueryPartitioning=<day|hour|month|year|null>] An optional arg specifying what partitioning to use for the output BigQuery table, or 'null' for no partitioning. Defaults to DAY.
+        |  [--bigqueryPartitioning=<day|hour|month|year|null>] An optional arg specifying what partitioning to use for the output BigQuery table, or 'null' for no partitioning. Defaults to day.
         |
         |
         |Since this runs a Scio/Beam pipeline, Dataflow options will have to be provided. At a

--- a/ratatool-sampling/src/main/scala/com/spotify/ratatool/samplers/BigSamplerBigQuery.scala
+++ b/ratatool-sampling/src/main/scala/com/spotify/ratatool/samplers/BigSamplerBigQuery.scala
@@ -153,7 +153,8 @@ private[samplers] object BigSamplerBigQuery {
     distributionFields: List[String],
     precision: Precision,
     sizePerKey: Int,
-    byteEncoding: ByteEncoding = RawEncoding
+    byteEncoding: ByteEncoding = RawEncoding,
+    bigqueryPartitioning: String
   ): ClosedTap[TableRow] = {
     import BigQueryIO.Write.CreateDisposition.CREATE_IF_NEEDED
     import BigQueryIO.Write.WriteDisposition.WRITE_EMPTY
@@ -183,6 +184,10 @@ private[samplers] object BigSamplerBigQuery {
         byteEncoding
       )
 
+      val partitioning = bigqueryPartitioning match {
+        case "NULL" => null
+        case _      => TimePartitioning(bigqueryPartitioning)
+      }
       val r = sampledCollection
         .saveAsBigQueryTable(
           Table.Ref(outputTbl),
@@ -190,7 +195,7 @@ private[samplers] object BigSamplerBigQuery {
           WRITE_EMPTY,
           CREATE_IF_NEEDED,
           tableDescription = "",
-          TimePartitioning("DAY")
+          partitioning
         )
       sc.run().waitUntilDone()
       r


### PR DESCRIPTION
adds a new arg to BigSampler called `bigqueryPartitioning`, defaults to "DAY", which should maintain the same behavior as before. Users can pass in "DAY|HOUR|MONTH|YEAR", as well as NULL if no table partitioning is desired. 

Making this change so that Ratatool works better with Spotify's internal Luigi BigQuery tasks, which use table sharding as partitioning, and when ratatool sets the partitioning to ingestion day, it causes problems with retention.

Tested by outputting [this](https://console.cloud.google.com/bigquery?project=data-quality-spotify&ws=!1m5!1m4!4m3!1sdata-quality-spotify!2sbenk_test_eu!3sbenk_test_eu_20240219) table via this workflow:

```
apiVersion: workflow.data.spotify.com/v1alpha1
kind: Workflow
metadata:
  name: ratatool-internal-examples-stream-days-bigsampler
  namespace: data-quality-spotify
spec:
  resourceID: ratatool-internal-examples.stream.days.BigSampler
  componentID: ratatool-internal
  scheduling:
    schedule: daily
  serviceAccountRef:
    external: contours-test-pipeline@data-quality-spotify.iam.gserviceaccount.com
  docker:
    args:
      - 'wrap-luigi'
      - '--module'
      - 'luigi_tasks'
      - 'BigSampler'
      - '--uri-prefix'
      - 'gs://benk-playground'
      - '--project'
      - 'data-quality-spotify'
      - '--service-account'
      - 'contours-test-pipeline@data-quality-spotify.iam.gserviceaccount.com'
      - '--input-endpoint'
      - 'spotify-people:groups.groups_%Y%m%d'
      - '--output-endpoint'
      - 'data-quality-spotify:benk_test_eu.benk_test_eu_%Y%m%d'
      - '--sample'
      - '0.01'
      - '--partition'
      - '{}'
    terminationLogging: true
    image: 43ea5c916cd5a85623bf0de598da15982c29d8952dbf63a068d10e5b56466e61
  workflowAlertingDisabled: true
```

the `43ea5c916cd5a85623bf0de598da15982c29d8952dbf63a068d10e5b56466e61` docker image is using my local ratatool PR's code via `sbt publishM2`

the linked table has to partitioning and uses the sharding generated by the BigQueryTarget in Luigi

[here](https://console.cloud.google.com/bigquery?project=data-quality-spotify&ws=!1m5!1m4!4m3!1sdata-quality-spotify!2sbenk_test_eu2!3sbenk_test_eu_20240220) is another table that is using the `--bigquery-partitioning` arg to set the partitioning to "MONTH".