### PR TITLE
Support java-class stringable property

### DIFF
--- a/ratatool-scalacheck/src/main/scala/com/spotify/ratatool/scalacheck/HashMapBuildable.scala
+++ b/ratatool-scalacheck/src/main/scala/com/spotify/ratatool/scalacheck/HashMapBuildable.scala
@@ -22,8 +22,8 @@ private[scalacheck] object HashMapBuildable {
 
   import scala.jdk.CollectionConverters._
 
-  implicit val tt: java.util.HashMap[CharSequence, Any] => Traversable[(CharSequence, Any)] =
-    _.asScala
+  implicit def toTraversable[K, V]: java.util.HashMap[K, V] => Traversable[(K, V)] = _.asScala
+
   implicit def buildableHashMap[K, V]: Buildable[(K, V), java.util.HashMap[K, V]] =
     new Buildable[(K, V), java.util.HashMap[K, V]] {
       def builder = new HashMapBuilder[K, V]

--- a/ratatool-scalacheck/src/main/scala/com/spotify/ratatool/scalacheck/HashMapBuildable.scala
+++ b/ratatool-scalacheck/src/main/scala/com/spotify/ratatool/scalacheck/HashMapBuildable.scala
@@ -22,7 +22,7 @@ private[scalacheck] object HashMapBuildable {
 
   import scala.jdk.CollectionConverters._
 
-  implicit def toTraversable[K, V]: java.util.HashMap[K, V] => Traversable[(K, V)] = _.asScala
+  implicit def tt[K, V]: java.util.HashMap[K, V] => Traversable[(K, V)] = _.asScala
 
   implicit def buildableHashMap[K, V]: Buildable[(K, V), java.util.HashMap[K, V]] =
     new Buildable[(K, V), java.util.HashMap[K, V]] {


### PR DESCRIPTION
Attempt to support `java-class` and `java-key-class` as defined in the avro [specification](https://avro.apache.org/docs/1.11.1/api/java/)

`java-element-class` is only used in the reflect API